### PR TITLE
adding ability to copy calldata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "tailwind-merge": "^2.2.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "viem": "^2.23.14"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",
@@ -36,6 +37,11 @@
         "tailwindcss": "^3.4.1",
         "vite": "^5.0.8"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -876,6 +882,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1239,6 +1270,39 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "dependencies": {
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1334,6 +1398,26 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -2587,6 +2671,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3597,6 +3686,20 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/isows": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4093,6 +4196,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -5560,6 +5691,35 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/viem": {
+      "version": "2.23.14",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.14.tgz",
+      "integrity": "sha512-ol8UKYT418u+7Lg83Ut7WJe7iOn1daGAqaofCoPe5z7eGR/XCu3ydja7eL7Z5ffwp6r0RoXeWkpun78UYhKygA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
+        "isows": "1.0.6",
+        "ox": "0.6.9",
+        "ws": "8.18.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.14",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
@@ -5818,6 +5978,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwind-merge": "^2.2.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "viem": "^2.23.14"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -1,53 +1,144 @@
-import React, { useState, useEffect } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Copy, Check, Code, ChevronDown, ChevronUp } from 'lucide-react';
-import { generateFlowMatrixParams } from '@/lib/utils';
+import React, { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Copy, Check, Code, ChevronDown, ChevronUp } from "lucide-react";
+import { generateFlowMatrixParams } from "@/lib/utils";
+import { encodeFunctionData } from "viem";
+
+// Just the operateFlowMatrix function ABI
+const OPERATE_FLOW_MATRIX_ABI = [
+  {
+    inputs: [
+      {
+        internalType: "address[]",
+        name: "_flowVertices",
+        type: "address[]",
+      },
+      {
+        components: [
+          {
+            internalType: "uint16",
+            name: "streamSinkId",
+            type: "uint16",
+          },
+          {
+            internalType: "uint192",
+            name: "amount",
+            type: "uint192",
+          },
+        ],
+        internalType: "struct TypeDefinitions.FlowEdge[]",
+        name: "_flow",
+        type: "tuple[]",
+      },
+      {
+        components: [
+          {
+            internalType: "uint16",
+            name: "sourceCoordinate",
+            type: "uint16",
+          },
+          {
+            internalType: "uint16[]",
+            name: "flowEdgeIds",
+            type: "uint16[]",
+          },
+          {
+            internalType: "bytes",
+            name: "data",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct TypeDefinitions.Stream[]",
+        name: "_streams",
+        type: "tuple[]",
+      },
+      {
+        internalType: "bytes",
+        name: "_packedCoordinates",
+        type: "bytes",
+      },
+    ],
+    name: "operateFlowMatrix",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];
 
 const FlowMatrixParams = ({ pathData, sender }) => {
   const [params, setParams] = useState(null);
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState({ json: false, calldata: false });
   const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     if (!pathData || !sender) return;
-    // Generate params using the sender as the "from" address
     const flowParams = generateFlowMatrixParams(pathData, sender);
     setParams(flowParams);
   }, [pathData, sender]);
 
-  const copyToClipboard = () => {
+  const copyToClipboard = async (type) => {
     if (!params) return;
-    
-    const formatted = JSON.stringify({
-      method: "operateFlowMatrix",
-      params
-    }, null, 2);
-    
-    navigator.clipboard.writeText(formatted);
-    setCopied(true);
-    
+
+    let textToCopy;
+
+    if (type === "json") {
+      textToCopy = JSON.stringify(
+        {
+          method: "operateFlowMatrix",
+          params,
+        },
+        null,
+        2,
+      );
+    } else if (type === "calldata") {
+      try {
+        const calldata = encodeFunctionData({
+          abi: OPERATE_FLOW_MATRIX_ABI,
+          functionName: "operateFlowMatrix",
+          args: [
+            params._flowVertices,
+            params._flow,
+            params._streams,
+            params._packedCoordinates,
+          ],
+        });
+        textToCopy = calldata;
+      } catch (error) {
+        console.error("Error generating calldata:", error);
+        return;
+      }
+    }
+
+    await navigator.clipboard.writeText(textToCopy);
+    setCopied((prev) => ({ ...prev, [type]: true }));
+
     setTimeout(() => {
-      setCopied(false);
+      setCopied((prev) => ({ ...prev, [type]: false }));
     }, 2000);
   };
 
   if (!params) return null;
 
-  // For UI clarity, create shorter versions with limited data
   const shortParams = {
     ...params,
-    _flowVertices: params._flowVertices.length > 3 
-      ? [...params._flowVertices.slice(0, 3), '...'] 
-      : params._flowVertices,
-    _flow: params._flow.length > 3 
-      ? [...params._flow.slice(0, 3), '...'] 
-      : params._flow
+    _flowVertices:
+      params._flowVertices.length > 3
+        ? [...params._flowVertices.slice(0, 3), "..."]
+        : params._flowVertices,
+    _flow:
+      params._flow.length > 3
+        ? [...params._flow.slice(0, 3), "..."]
+        : params._flow,
   };
 
-  const formattedJson = expanded 
+  const formattedJson = expanded
     ? JSON.stringify({ method: "operateFlowMatrix", params }, null, 2)
-    : JSON.stringify({ method: "operateFlowMatrix", params: shortParams }, null, 2);
+    : JSON.stringify(
+        { method: "operateFlowMatrix", params: shortParams },
+        null,
+        2,
+      );
 
   return (
     <Card className="mt-4">
@@ -55,31 +146,39 @@ const FlowMatrixParams = ({ pathData, sender }) => {
         <div className="flex justify-between items-center mb-2">
           <div className="flex items-center gap-2">
             <Code size={18} className="text-blue-500" />
-            <h2 className="text-lg font-semibold">operateFlowMatrix Parameters</h2>
+            <h2 className="text-lg font-semibold">
+              operateFlowMatrix Parameters
+            </h2>
           </div>
           <div className="flex gap-2">
-            <Button 
+            <Button
               onClick={() => setExpanded(!expanded)}
               variant="outline"
               className="flex items-center gap-1"
             >
               {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-              {expanded ? 'Show Less' : 'Show Full Params'}
+              {expanded ? "Show Less" : "Show Full Params"}
             </Button>
-            <Button 
-              onClick={copyToClipboard} 
+            <Button
+              onClick={() => copyToClipboard("json")}
+              variant="outline"
               className="flex items-center gap-1"
             >
-              {copied ? <Check size={16} /> : <Copy size={16} />}
-              {copied ? 'Copied!' : 'Copy'}
+              {copied.json ? <Check size={16} /> : <Copy size={16} />}
+              {copied.json ? "Copied!" : "Copy JSON"}
+            </Button>
+            <Button
+              onClick={() => copyToClipboard("calldata")}
+              className="flex items-center gap-1"
+            >
+              {copied.calldata ? <Check size={16} /> : <Copy size={16} />}
+              {copied.calldata ? "Copied!" : "Copy Calldata"}
             </Button>
           </div>
         </div>
         <div className="relative">
           <div className="bg-gray-50 p-4 rounded-md overflow-auto max-h-96 font-mono text-sm">
-            <pre className="whitespace-pre-wrap text-left">
-              {formattedJson}
-            </pre>
+            <pre className="whitespace-pre-wrap text-left">{formattedJson}</pre>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
Added a button to copy the hex-encoded calldata for the call to simplify the generation of transactions. Required adding viem as a lightweight dependency. 