### PR TITLE
feat: inline Safe transaction simulation

### DIFF
--- a/src/components/CollapsibleLeftPanel.jsx
+++ b/src/components/CollapsibleLeftPanel.jsx
@@ -10,10 +10,14 @@ const CollapsibleLeftPanel = ({
   isCollapsed,
   setIsCollapsed,
   formData,
+  formErrors,
+  formWarnings,
   handleInputChange,
   handleTokensChange,
   handleWithWrapToggle,
   handleStagingToggle,
+  handleQuantizedModeToggle,
+  handleDebugIntermediateToggle,
   handleFromTokensExclusionToggle,
   handleToTokensExclusionToggle,
   onFindPath,
@@ -86,10 +90,14 @@ const CollapsibleLeftPanel = ({
             {expandedSections.form && (
               <PathFinderForm
                 formData={formData}
+                formErrors={formErrors}
+                formWarnings={formWarnings}
                 handleInputChange={handleInputChange}
                 handleTokensChange={handleTokensChange}
                 handleWithWrapToggle={handleWithWrapToggle}
                 handleStagingToggle={handleStagingToggle}
+                handleQuantizedModeToggle={handleQuantizedModeToggle}
+                handleDebugIntermediateToggle={handleDebugIntermediateToggle}
                 handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}
                 handleToTokensExclusionToggle={handleToTokensExclusionToggle}
                 onFindPath={onFindPath}

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -5,9 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Copy, Check, Code, ChevronDown, ChevronUp, Wallet, Send, X, AlertTriangle } from "lucide-react";
 import { createFlowMatrix } from "@aboutcircles/sdk-pathfinder";
 import { encodeFunctionData } from "viem";
-import { useAccount, useConnect, useDisconnect, useSwitchChain, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useConnect, useDisconnect, useSwitchChain, useWriteContract, useWaitForTransactionReceipt, usePublicClient } from "wagmi";
 import { gnosis } from "wagmi/chains";
 import { HUB_ADDRESS } from "@/config/wagmi";
+import { buildSafeFlowMatrixSimulationTx } from "@/services/circlesApi";
 
 // Just the operateFlowMatrix function ABI
 const OPERATE_FLOW_MATRIX_ABI = [
@@ -72,18 +73,62 @@ const OPERATE_FLOW_MATRIX_ABI = [
 
 const HUB_V2_ADDRESS = '0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8';
 
+const SAFE_OWNERS_ABI = [
+  {
+    type: 'function',
+    name: 'getOwners',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address[]' }],
+  },
+];
+
 function bytesToHex(bytes) {
   return '0x' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
-const FlowMatrixParams = ({ pathData, sender, receiver, showProcessed, isFiltered }) => {
+const resolveSimulationSigner = async ({ publicClient, safeAddress, connectedAddress }) => {
+  const normalizedSafe = safeAddress?.toLowerCase?.();
+  const normalizedConnected = connectedAddress?.toLowerCase?.();
+
+  const owners = await publicClient.readContract({
+    address: normalizedSafe,
+    abi: SAFE_OWNERS_ABI,
+    functionName: 'getOwners',
+  });
+
+  const normalizedOwners = (owners || []).map((owner) => owner?.toLowerCase?.()).filter(Boolean);
+  if (normalizedOwners.length === 0) {
+    throw new Error(`No Safe owners found for sender safe ${normalizedSafe}.`);
+  }
+
+  if (normalizedConnected && normalizedOwners.includes(normalizedConnected)) {
+    return {
+      signer: normalizedConnected,
+      owners: normalizedOwners,
+      usesConnectedWallet: true,
+    };
+  }
+
+  return {
+    signer: normalizedOwners[0],
+    owners: normalizedOwners,
+    usesConnectedWallet: false,
+  };
+};
+
+const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcessed, isFiltered }) => {
   const [flowMatrix, setFlowMatrix] = useState(null);
   const [error, setError] = useState(null);
   const [copied, setCopied] = useState({ json: false, calldata: false });
   const [expanded, setExpanded] = useState(false);
   const [showWalletModal, setShowWalletModal] = useState(false);
+  const [isSimulating, setIsSimulating] = useState(false);
+  const [simulationError, setSimulationError] = useState(null);
+  const [simulationResult, setSimulationResult] = useState(null);
 
   const { address, isConnected, chain } = useAccount();
+  const publicClient = usePublicClient();
   const { connectors, connect } = useConnect();
   const { disconnect } = useDisconnect();
   const { switchChain } = useSwitchChain();
@@ -247,6 +292,79 @@ const FlowMatrixParams = ({ pathData, sender, receiver, showProcessed, isFiltere
     }
   };
 
+  const handleSimulateTransaction = async () => {
+    const simulationPathData = rawPathData || pathData;
+    if (!simulationPathData || !sender || !receiver || !address || !publicClient) return;
+
+    setSimulationError(null);
+    setSimulationResult(null);
+    setIsSimulating(true);
+
+    try {
+      const signerSelection = await resolveSimulationSigner({
+        publicClient,
+        safeAddress: sender,
+        connectedAddress: address,
+      });
+
+      const simulationTx = await buildSafeFlowMatrixSimulationTx({
+        pathData: simulationPathData,
+        sender,
+        receiver,
+        signer: signerSelection.signer,
+        hubAddress: HUB_ADDRESS,
+      });
+
+      console.groupCollapsed('[FlowMatrix] Safe simulation');
+      console.info('Simulation context', {
+        sender: sender?.toLowerCase?.(),
+        receiver: receiver?.toLowerCase?.(),
+        connectedWallet: address?.toLowerCase?.(),
+        simulationSigner: signerSelection.signer,
+        safeOwners: signerSelection.owners,
+        signerSelection: signerSelection.usesConnectedWallet
+          ? 'connected wallet is a Safe owner'
+          : 'connected wallet is not a Safe owner; using first Safe owner',
+        safeAddress: simulationTx.safeAddress,
+        gasFrom: simulationTx.gasFrom,
+      });
+      if (simulationTx.simulationLog) {
+        console.log(simulationTx.simulationLog);
+      }
+
+      const gas = await publicClient.estimateGas({
+        account: simulationTx.gasFrom,
+        to: simulationTx.safeAddress,
+        data: simulationTx.safeCalldata,
+      });
+
+      console.info('Estimated gas', gas.toString());
+      console.groupEnd();
+
+      if (gas === 0n) {
+        throw new Error('Gas estimation returned 0 – path likely too long for a single block.');
+      }
+
+      setSimulationResult({
+        gas,
+        ...simulationTx.summary,
+        simulationLog: simulationTx.simulationLog,
+      });
+    } catch (err) {
+      console.error('[FlowMatrix] Safe simulation failed', err);
+      if (console.groupEnd) {
+        try {
+          console.groupEnd();
+        } catch {
+          // no-op
+        }
+      }
+      setSimulationError(err?.shortMessage || err?.message || 'Simulation failed');
+    } finally {
+      setIsSimulating(false);
+    }
+  };
+
   if (error) {
     return (
       <Card className="mt-4">
@@ -355,6 +473,14 @@ const FlowMatrixParams = ({ pathData, sender, receiver, showProcessed, isFiltere
                   </Button>
                 )}
                 <Button
+                  onClick={handleSimulateTransaction}
+                  disabled={!isConnected || isWrongChain || isSimulating}
+                  variant="outline"
+                  className="flex items-center gap-1"
+                >
+                  {isSimulating ? 'Simulating…' : 'Simulate'}
+                </Button>
+                <Button
                   onClick={() => disconnect()}
                   variant="outline"
                   className="flex items-center gap-1"
@@ -384,6 +510,30 @@ const FlowMatrixParams = ({ pathData, sender, receiver, showProcessed, isFiltere
             Transaction submitted: {hash.slice(0, 10)}...{hash.slice(-8)}
             {isConfirming && " - Confirming..."}
             {isConfirmed && " - Confirmed!"}
+          </div>
+        )}
+
+        {simulationError && (
+          <div className="mb-2 p-2 bg-red-100 text-red-700 rounded text-sm">
+            Simulation error: {simulationError}
+          </div>
+        )}
+
+        {simulationResult && (
+          <div className="mb-3 p-3 bg-blue-50 border border-blue-200 rounded text-sm text-blue-900 space-y-1">
+            <div className="font-medium">Safe simulation</div>
+            <div>Estimated gas: {simulationResult.gas.toString()}</div>
+            <div>Wrapped sender edges: {simulationResult.wrappedEdgesFromSender}</div>
+            <div>Sub-calls: {simulationResult.calls} (unwrap: {simulationResult.unwrapCalls}, re-wrap: {simulationResult.wrapCalls})</div>
+            <div className="text-xs text-blue-700">Order: self-approval → unwrap(s) → operateFlowMatrix → re-wrap(s)</div>
+            {simulationResult.simulationLog && (
+              <div className="mt-2">
+                <div className="text-xs font-medium uppercase tracking-wide text-blue-700">Simulation log</div>
+                <pre className="mt-1 max-h-64 overflow-auto rounded border border-blue-200 bg-white/70 p-2 font-mono text-xs text-blue-900 whitespace-pre-wrap text-left">
+                  {simulationResult.simulationLog}
+                </pre>
+              </div>
+            )}
           </div>
         )}
 
@@ -449,7 +599,11 @@ const FlowMatrixParams = ({ pathData, sender, receiver, showProcessed, isFiltere
 
 FlowMatrixParams.propTypes = {
   pathData: PropTypes.object,
+  rawPathData: PropTypes.object,
   sender: PropTypes.string,
+  receiver: PropTypes.string,
+  showProcessed: PropTypes.bool,
+  isFiltered: PropTypes.bool,
 };
 
 export default FlowMatrixParams;

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -97,11 +97,18 @@ const resolveSimulationSigner = async ({ publicClient, safeAddress, connectedAdd
   const normalizedSafe = safeAddress?.toLowerCase?.();
   const normalizedConnected = connectedAddress?.toLowerCase?.();
 
-  const owners = await publicClient.readContract({
-    address: normalizedSafe,
-    abi: SAFE_OWNERS_ABI,
-    functionName: 'getOwners',
-  });
+  let owners;
+  try {
+    owners = await publicClient.readContract({
+      address: normalizedSafe,
+      abi: SAFE_OWNERS_ABI,
+      functionName: 'getOwners',
+    });
+  } catch {
+    throw new Error(
+      `Could not read Safe owners for ${normalizedSafe}. Ensure the sender address is a deployed Gnosis Safe contract.`
+    );
+  }
 
   const normalizedOwners = (owners || []).map((owner) => owner?.toLowerCase?.()).filter(Boolean);
   if (normalizedOwners.length === 0) {

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -87,6 +87,12 @@ function bytesToHex(bytes) {
   return '0x' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
+const toDisplayValue = (value) => {
+  if (typeof value === 'bigint') return value.toString();
+  if (value === null || value === undefined) return '—';
+  return String(value);
+};
+
 const resolveSimulationSigner = async ({ publicClient, safeAddress, connectedAddress }) => {
   const normalizedSafe = safeAddress?.toLowerCase?.();
   const normalizedConnected = connectedAddress?.toLowerCase?.();
@@ -125,6 +131,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
   const [showWalletModal, setShowWalletModal] = useState(false);
   const [isSimulating, setIsSimulating] = useState(false);
   const [simulationError, setSimulationError] = useState(null);
+  const [simulationErrorLog, setSimulationErrorLog] = useState('');
   const [simulationResult, setSimulationResult] = useState(null);
 
   const { address, isConnected, chain } = useAccount();
@@ -297,8 +304,10 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
     if (!simulationPathData || !sender || !receiver || !address || !publicClient) return;
 
     setSimulationError(null);
+    setSimulationErrorLog('');
     setSimulationResult(null);
     setIsSimulating(true);
+    let lastSimulationLog = '';
 
     try {
       const signerSelection = await resolveSimulationSigner({
@@ -307,13 +316,16 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
         connectedAddress: address,
       });
 
-      const simulationTx = await buildSafeFlowMatrixSimulationTx({
+      const buildSimulationTx = () => buildSafeFlowMatrixSimulationTx({
         pathData: simulationPathData,
         sender,
         receiver,
         signer: signerSelection.signer,
         hubAddress: HUB_ADDRESS,
       });
+
+      const simulationTx = await buildSimulationTx();
+      lastSimulationLog = simulationTx?.simulationLog || '';
 
       console.groupCollapsed('[FlowMatrix] Safe simulation');
       console.info('Simulation context', {
@@ -348,6 +360,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
       setSimulationResult({
         gas,
         ...simulationTx.summary,
+        diagnostics: simulationTx.diagnostics,
         simulationLog: simulationTx.simulationLog,
       });
     } catch (err) {
@@ -360,6 +373,10 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
         }
       }
       setSimulationError(err?.shortMessage || err?.message || 'Simulation failed');
+      setSimulationErrorLog(
+        lastSimulationLog ||
+        ((typeof err?.simulationLog === 'string' && err.simulationLog) || '')
+      );
     } finally {
       setIsSimulating(false);
     }
@@ -514,8 +531,16 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
         )}
 
         {simulationError && (
-          <div className="mb-2 p-2 bg-red-100 text-red-700 rounded text-sm">
-            Simulation error: {simulationError}
+          <div className="mb-2 p-2 bg-red-100 text-red-700 rounded text-sm space-y-2">
+            <div>Simulation error: {simulationError}</div>
+            {simulationErrorLog && (
+              <div>
+                <div className="text-xs font-medium uppercase tracking-wide text-red-800">Simulation log (until error)</div>
+                <pre className="mt-1 max-h-64 overflow-auto rounded border border-red-200 bg-white/70 p-2 font-mono text-xs text-red-900 whitespace-pre-wrap text-left">
+                  {simulationErrorLog}
+                </pre>
+              </div>
+            )}
           </div>
         )}
 
@@ -524,8 +549,107 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
             <div className="font-medium">Safe simulation</div>
             <div>Estimated gas: {simulationResult.gas.toString()}</div>
             <div>Wrapped sender edges: {simulationResult.wrappedEdgesFromSender}</div>
+            {simulationResult.wrappedEdgesByType && (
+              <div className="text-xs text-blue-800">
+                Wrapped edge types: static {simulationResult.wrappedEdgesByType.static} · demurraged {simulationResult.wrappedEdgesByType.demurraged}
+              </div>
+            )}
             <div>Sub-calls: {simulationResult.calls} (unwrap: {simulationResult.unwrapCalls}, re-wrap: {simulationResult.wrapCalls})</div>
+            {simulationResult.unwrapByType && (
+              <div className="text-xs text-blue-800">
+                Unwrap targets: static {simulationResult.unwrapByType.static} · demurraged {simulationResult.unwrapByType.demurraged}
+              </div>
+            )}
             <div className="text-xs text-blue-700">Order: self-approval → unwrap(s) → operateFlowMatrix → re-wrap(s)</div>
+
+            {simulationResult.diagnostics?.staticWrappers?.length > 0 && (
+              <div className="mt-2">
+                <div className="text-xs font-medium uppercase tracking-wide text-blue-700">Static wrappers</div>
+                <div className="mt-1 overflow-auto rounded border border-blue-200 bg-white/80">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-blue-100/70 text-blue-900">
+                      <tr>
+                        <th className="px-2 py-1 text-left">Wrapper</th>
+                        <th className="px-2 py-1 text-right">Path demurraged</th>
+                        <th className="px-2 py-1 text-right">Unwrapped static</th>
+                        <th className="px-2 py-1 text-right">Unwrapped demurraged</th>
+                        <th className="px-2 py-1 text-right">Spent demurraged</th>
+                        <th className="px-2 py-1 text-right">Re-wrap demurraged</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {simulationResult.diagnostics.staticWrappers.map((row) => (
+                        <tr key={row.wrapper} className="border-t border-blue-100">
+                          <td className="px-2 py-1 font-mono text-[11px]">{row.wrapper}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.pathDemurraged)}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.staticBalanceUnwrapped)}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.demurragedBalanceUnwrapped)}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.demurragedSpent)}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.demurragedRemainingToWrap)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {simulationResult.diagnostics?.demurragedWrappers?.length > 0 && (
+              <div className="mt-2">
+                <div className="text-xs font-medium uppercase tracking-wide text-blue-700">Demurraged wrappers</div>
+                <div className="mt-1 overflow-auto rounded border border-blue-200 bg-white/80">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-blue-100/70 text-blue-900">
+                      <tr>
+                        <th className="px-2 py-1 text-left">Wrapper</th>
+                        <th className="px-2 py-1 text-right">Path demurraged</th>
+                        <th className="px-2 py-1 text-right">Unwrap demurraged</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {simulationResult.diagnostics.demurragedWrappers.map((row) => (
+                        <tr key={row.wrapper} className="border-t border-blue-100">
+                          <td className="px-2 py-1 font-mono text-[11px]">{row.wrapper}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.pathDemurraged)}</td>
+                          <td className="px-2 py-1 text-right font-mono">{toDisplayValue(row.demurragedUnwrapAmount)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {simulationResult.diagnostics?.callTimeline?.length > 0 && (
+              <div className="mt-2">
+                <div className="text-xs font-medium uppercase tracking-wide text-blue-700">Sub-call timeline</div>
+                <div className="mt-1 overflow-auto rounded border border-blue-200 bg-white/80">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-blue-100/70 text-blue-900">
+                      <tr>
+                        <th className="px-2 py-1 text-right">#</th>
+                        <th className="px-2 py-1 text-left">Action</th>
+                        <th className="px-2 py-1 text-left">To</th>
+                        <th className="px-2 py-1 text-left">Selector</th>
+                        <th className="px-2 py-1 text-right">Bytes</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {simulationResult.diagnostics.callTimeline.map((row) => (
+                        <tr key={`${row.index}-${row.selector}`} className="border-t border-blue-100">
+                          <td className="px-2 py-1 text-right font-mono">{row.index}</td>
+                          <td className="px-2 py-1">{row.label}</td>
+                          <td className="px-2 py-1 font-mono text-[11px]">{row.to}</td>
+                          <td className="px-2 py-1 font-mono">{row.selector}</td>
+                          <td className="px-2 py-1 text-right font-mono">{row.dataLengthBytes}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
             {simulationResult.simulationLog && (
               <div className="mt-2">
                 <div className="text-xs font-medium uppercase tracking-wide text-blue-700">Simulation log</div>

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -123,7 +123,9 @@ const resolveSimulationSigner = async ({ publicClient, safeAddress, connectedAdd
   };
 };
 
-const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcessed, isFiltered }) => {
+const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcessed, isFiltered, view = 'all' }) => {
+  const showParamsSection = view !== 'simulation';
+  const showSimulationSection = view !== 'params';
   const [flowMatrix, setFlowMatrix] = useState(null);
   const [error, setError] = useState(null);
   const [copied, setCopied] = useState({ json: false, calldata: false });
@@ -145,6 +147,12 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
   });
 
   useEffect(() => {
+    if (!showParamsSection) {
+      setFlowMatrix(null);
+      setError(null);
+      return;
+    }
+
     if (!pathData || !sender) return;
     setError(null);
 
@@ -165,7 +173,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
       setError(err.message);
       setFlowMatrix(null);
     }
-  }, [pathData, sender, receiver]);
+  }, [pathData, sender, receiver, showParamsSection]);
 
   useEffect(() => {
     if (writeError) {
@@ -382,7 +390,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
     }
   };
 
-  if (error) {
+  if (error && showParamsSection) {
     return (
       <Card className="mt-4">
         <CardContent className="pt-4">
@@ -392,22 +400,26 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
     );
   }
 
-  if (!flowMatrix) return null;
+  if (showParamsSection && !flowMatrix) return null;
 
-  const params = getJsonParams();
-  const shortParams = {
-    ...params,
-    _flowVertices: params._flowVertices.length > 3 ? [...params._flowVertices.slice(0, 3), "..."] : params._flowVertices,
-    _flow: params._flow.length > 3 ? [...params._flow.slice(0, 3), "..."] : params._flow,
-  };
+  const params = showParamsSection ? getJsonParams() : null;
+  const shortParams = showParamsSection && params
+    ? {
+        ...params,
+        _flowVertices: params._flowVertices.length > 3 ? [...params._flowVertices.slice(0, 3), "..."] : params._flowVertices,
+        _flow: params._flow.length > 3 ? [...params._flow.slice(0, 3), "..."] : params._flow,
+      }
+    : null;
 
-  const formattedJson = expanded
+  const formattedJson = showParamsSection
+    ? (expanded
     ? JSON.stringify({ method: "operateFlowMatrix", params }, null, 2)
-    : JSON.stringify({ method: "operateFlowMatrix", params: shortParams }, null, 2);
+    : JSON.stringify({ method: "operateFlowMatrix", params: shortParams }, null, 2))
+    : null;
 
   let calldata = null;
   try {
-    calldata = getCalldata();
+    calldata = showParamsSection ? getCalldata() : null;
   } catch (err) {
     // will show error inline
   }
@@ -433,35 +445,41 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
           <div className="flex items-center gap-2">
             <Code size={18} className="text-blue-500" />
             <h2 className="text-lg font-semibold">
-              operateFlowMatrix
+              {showSimulationSection && !showParamsSection ? 'Flow Matrix Simulation' : 'operateFlowMatrix'}
             </h2>
-            <span className="text-xs text-gray-400 font-mono">{HUB_V2_ADDRESS.slice(0, 10)}…</span>
+            {showParamsSection && (
+              <span className="text-xs text-gray-400 font-mono">{HUB_V2_ADDRESS.slice(0, 10)}…</span>
+            )}
           </div>
           <div className="flex gap-2 flex-wrap">
-            <Button
-              onClick={() => setExpanded(!expanded)}
-              variant="outline"
-              className="flex items-center gap-1"
-            >
-              {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-              {expanded ? "Less" : "Full"}
-            </Button>
-            <Button
-              onClick={() => copyToClipboard("json")}
-              variant="outline"
-              className="flex items-center gap-1"
-            >
-              {copied.json ? <Check size={16} /> : <Copy size={16} />}
-              {copied.json ? "Copied!" : "JSON"}
-            </Button>
-            <Button
-              onClick={() => copyToClipboard("calldata")}
-              variant="outline"
-              className="flex items-center gap-1"
-            >
-              {copied.calldata ? <Check size={16} /> : <Copy size={16} />}
-              {copied.calldata ? "Copied!" : "Calldata"}
-            </Button>
+            {showParamsSection && (
+              <>
+                <Button
+                  onClick={() => setExpanded(!expanded)}
+                  variant="outline"
+                  className="flex items-center gap-1"
+                >
+                  {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                  {expanded ? "Less" : "Full"}
+                </Button>
+                <Button
+                  onClick={() => copyToClipboard("json")}
+                  variant="outline"
+                  className="flex items-center gap-1"
+                >
+                  {copied.json ? <Check size={16} /> : <Copy size={16} />}
+                  {copied.json ? "Copied!" : "JSON"}
+                </Button>
+                <Button
+                  onClick={() => copyToClipboard("calldata")}
+                  variant="outline"
+                  className="flex items-center gap-1"
+                >
+                  {copied.calldata ? <Check size={16} /> : <Copy size={16} />}
+                  {copied.calldata ? "Copied!" : "Calldata"}
+                </Button>
+              </>
+            )}
             {!isConnected ? (
               <Button
                 onClick={() => setShowWalletModal(true)}
@@ -480,23 +498,27 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
                     Switch to Gnosis Chain
                   </Button>
                 ) : (
+                  showParamsSection && (
+                    <Button
+                      onClick={handleExecuteTransaction}
+                      disabled={!canExecute}
+                      className="flex items-center gap-1 bg-green-600 hover:bg-green-700"
+                    >
+                      <Send size={16} />
+                      {isWritePending || isConfirming ? "Executing..." : isConfirmed ? "Transaction Confirmed!" : "Execute Transaction"}
+                    </Button>
+                  )
+                )}
+                {showSimulationSection && (
                   <Button
-                    onClick={handleExecuteTransaction}
-                    disabled={!canExecute}
-                    className="flex items-center gap-1 bg-green-600 hover:bg-green-700"
+                    onClick={handleSimulateTransaction}
+                    disabled={!isConnected || isWrongChain || isSimulating}
+                    variant="outline"
+                    className="flex items-center gap-1"
                   >
-                    <Send size={16} />
-                    {isWritePending || isConfirming ? "Executing..." : isConfirmed ? "Transaction Confirmed!" : "Execute Transaction"}
+                    {isSimulating ? 'Simulating…' : 'Simulate'}
                   </Button>
                 )}
-                <Button
-                  onClick={handleSimulateTransaction}
-                  disabled={!isConnected || isWrongChain || isSimulating}
-                  variant="outline"
-                  className="flex items-center gap-1"
-                >
-                  {isSimulating ? 'Simulating…' : 'Simulate'}
-                </Button>
                 <Button
                   onClick={() => disconnect()}
                   variant="outline"
@@ -530,7 +552,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
           </div>
         )}
 
-        {simulationError && (
+        {showSimulationSection && simulationError && (
           <div className="mb-2 p-2 bg-red-100 text-red-700 rounded text-sm space-y-2">
             <div>Simulation error: {simulationError}</div>
             {simulationErrorLog && (
@@ -544,7 +566,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
           </div>
         )}
 
-        {simulationResult && (
+        {showSimulationSection && simulationResult && (
           <div className="mb-3 p-3 bg-blue-50 border border-blue-200 rounded text-sm text-blue-900 space-y-1">
             <div className="font-medium">Safe simulation</div>
             <div>Estimated gas: {simulationResult.gas.toString()}</div>
@@ -661,12 +683,14 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
           </div>
         )}
 
-        <div className="relative">
-          <div className="bg-gray-50 p-4 rounded-md overflow-auto max-h-96 font-mono text-sm">
-            <pre className="whitespace-pre-wrap text-left">{formattedJson}</pre>
+        {showParamsSection && (
+          <div className="relative">
+            <div className="bg-gray-50 p-4 rounded-md overflow-auto max-h-96 font-mono text-sm">
+              <pre className="whitespace-pre-wrap text-left">{formattedJson}</pre>
+            </div>
           </div>
-        </div>
-        {calldata && (
+        )}
+        {showParamsSection && calldata && (
           <div className="mt-3">
             <p className="text-xs text-gray-500 mb-1">Encoded calldata ({calldata.length} chars)</p>
             <div className="bg-gray-50 p-2 rounded-md overflow-auto max-h-24 font-mono text-xs text-gray-600 break-all">
@@ -728,6 +752,7 @@ FlowMatrixParams.propTypes = {
   receiver: PropTypes.string,
   showProcessed: PropTypes.bool,
   isFiltered: PropTypes.bool,
+  view: PropTypes.oneOf(['all', 'params', 'simulation']),
 };
 
 export default FlowMatrixParams;

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -42,17 +42,22 @@ const FlowVisualization = () => {
   
   const { shouldAutoSimplify, setPreset, toggleFeature, config } = usePerformance();
   
-  const { 
+  const {
     formData, 
+    formErrors,
     handleInputChange, 
     handleTokensChange, 
     handleWithWrapToggle,
     handleStagingToggle,
+    handleQuantizedModeToggle,
+    handleDebugIntermediateToggle,
     handleFromTokensExclusionToggle,
     handleToTokensExclusionToggle,
     setFromTokensIncludeValue,
     setToTokensIncludeValue,
+    validateFormData,
   } = useFormData();
+  const [formWarnings, setFormWarnings] = useState([]);
   
   const {
     pathData,
@@ -399,8 +404,27 @@ const FlowVisualization = () => {
 
   const handleFindPath = useCallback(async (overrideFormData) => {
     const baseData = overrideFormData || formData;
+    const validation = validateFormData(baseData);
+    setFormWarnings(validation.warnings || []);
+    if (!validation.isValid) {
+      return;
+    }
     await executeFindPath(baseData);
-  }, [formData, executeFindPath]);
+  }, [formData, executeFindPath, validateFormData]);
+
+  const noPathSuggestions = useMemo(() => {
+    if (!pathData) return [];
+    const hasNoPath = String(pathData?.maxFlow || '0') === '0' && (pathData?.transfers?.length || 0) === 0;
+    if (!hasNoPath) return [];
+
+    return [
+      'Remove token exclusions',
+      'Clear token allowlists',
+      'Disable Quantized Mode',
+      'Try enabling wrapped tokens',
+      'Add simulated trust/balance entries',
+    ];
+  }, [pathData]);
 
   const isQuickTokenSelected = useCallback((tokenAddress) => {
     if (!tokenAddress) return false;
@@ -792,10 +816,14 @@ const FlowVisualization = () => {
             isCollapsed={isCollapsed}
             setIsCollapsed={setIsCollapsed}
             formData={formData}
+            formErrors={formErrors}
+            formWarnings={formWarnings}
             handleInputChange={handleInputChange}
             handleTokensChange={handleTokensChange}
             handleWithWrapToggle={handleWithWrapToggle}
             handleStagingToggle={handleStagingToggle}
+            handleQuantizedModeToggle={handleQuantizedModeToggle}
+            handleDebugIntermediateToggle={handleDebugIntermediateToggle}
             handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}
             handleToTokensExclusionToggle={handleToTokensExclusionToggle}
             onFindPath={handleFindPath}
@@ -923,6 +951,18 @@ const FlowVisualization = () => {
                     </p>
                   </div>
                 </div>
+              )}
+              {noPathSuggestions.length > 0 && (
+                <Card className="absolute bottom-4 left-4 z-10 bg-amber-50 border-amber-200 max-w-sm">
+                  <CardContent className="p-3">
+                    <p className="text-xs font-semibold text-amber-800">No feasible route under current constraints</p>
+                    <ul className="mt-1 list-disc list-inside text-xs text-amber-700">
+                      {noPathSuggestions.map((tip) => (
+                        <li key={tip}>{tip}</li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
               )}
             </div>
 
@@ -1188,6 +1228,7 @@ const FlowVisualization = () => {
                     <TabsContent isActive={activeTab === 'parameters'} className="h-full">
                       <FlowMatrixParams
                         pathData={filteredPathData || pathData}
+                        rawPathData={rawPathData}
                         sender={formData.From}
                         receiver={formData.To}
                         showProcessed={showProcessed}

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -998,6 +998,12 @@ const FlowVisualization = () => {
                         Flow Matrix Parameters
                       </TabsTrigger>
                       <TabsTrigger
+                        isActive={activeTab === 'simulation'}
+                        onClick={() => setActiveTab('simulation')}
+                      >
+                        Simulation
+                      </TabsTrigger>
+                      <TabsTrigger
                         isActive={activeTab === 'stats'}
                         onClick={() => setActiveTab('stats')}
                       >
@@ -1233,6 +1239,19 @@ const FlowVisualization = () => {
                         receiver={formData.To}
                         showProcessed={showProcessed}
                         isFiltered={!!filteredPathData}
+                        view="params"
+                      />
+                    </TabsContent>
+
+                    <TabsContent isActive={activeTab === 'simulation'} className="h-full">
+                      <FlowMatrixParams
+                        pathData={filteredPathData || pathData}
+                        rawPathData={rawPathData}
+                        sender={formData.From}
+                        receiver={formData.To}
+                        showProcessed={showProcessed}
+                        isFiltered={!!filteredPathData}
+                        view="simulation"
                       />
                     </TabsContent>
                     

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -16,6 +16,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, GripHorizontal, User, Hash } from 'lucide-react';
+import InfoTip from '@/components/ui/info-tip';
 import PathStats from '@/components/PathStats';
 
 const FlowVisualization = () => {
@@ -27,8 +28,7 @@ const FlowVisualization = () => {
   const [sourceBalancesHeight, setSourceBalancesHeight] = usePersistedState('source-balances-height', 260);
   const [visualizationMode, setVisualizationMode] = usePersistedState('viz-mode', 'graph');
   const [showNames, setShowNames] = usePersistedState('show-names', true);
-  const [quickFromFilterEnabled, setQuickFromFilterEnabled] = usePersistedState('quick-from-filter-enabled', false);
-  const [quickToFilterEnabled, setQuickToFilterEnabled] = usePersistedState('quick-to-filter-enabled', false);
+  const [quickFilterEnabled, setQuickFilterEnabled] = usePersistedState('quick-filter-enabled', false);
   const [sourceBalanceSort, setSourceBalanceSort] = usePersistedState('source-balance-sort', { key: 'crc', direction: 'desc' });
   const [lowerPanelTab, setLowerPanelTab] = usePersistedState('lower-panel-tab', 'source');
   // selectedTransfers removed — route-based selection via selectedRouteIds
@@ -341,25 +341,32 @@ const FlowVisualization = () => {
   }, [loadPathData, clearHighlights]);
 
   const selectQuickTokensByPredicate = useCallback(async (predicate) => {
-    const nextTokens = Array.from(new Set(
+    const allTokens = Array.from(new Set(
+      (sourceBalances || [])
+        .map((row) => row?.tokenAddress?.toLowerCase())
+        .filter(Boolean)
+    ));
+    const selectedTokens = Array.from(new Set(
       (sourceBalances || [])
         .filter(predicate)
         .map((row) => row?.tokenAddress?.toLowerCase())
         .filter(Boolean)
     ));
-    const nextFromTokens = nextTokens.join(',');
+    const nextFromTokens = selectedTokens.join(',');
+    const excludedTokens = allTokens.filter(t => !selectedTokens.includes(t));
+    const nextExcludedFromTokens = excludedTokens.join(',');
 
     setFromTokensIncludeValue(nextFromTokens);
 
-    if (quickFromFilterEnabled) {
+    if (quickFilterEnabled) {
       await executeFindPath({
         ...formData,
         FromTokens: nextFromTokens,
-        ExcludedFromTokens: '',
+        ExcludedFromTokens: nextExcludedFromTokens,
         IsFromTokensExcluded: false,
       });
     }
-  }, [sourceBalances, setFromTokensIncludeValue, quickFromFilterEnabled, executeFindPath, formData]);
+  }, [sourceBalances, setFromTokensIncludeValue, quickFilterEnabled, executeFindPath, formData]);
 
   const selectAllQuickTokens = useCallback(async () => {
     await selectQuickTokensByPredicate(() => true);
@@ -412,6 +419,17 @@ const FlowVisualization = () => {
     await executeFindPath(baseData);
   }, [formData, executeFindPath, validateFormData]);
 
+  // Auto-run findPath on mount if form has sufficient persisted values
+  const hasAutoRun = useRef(false);
+  useEffect(() => {
+    if (hasAutoRun.current) return;
+    const isAddress = (v) => typeof v === 'string' && /^0x[a-fA-F0-9]{40}$/.test(v.trim());
+    if (isAddress(formData.From) && isAddress(formData.To) && formData.Amount && formData.Amount !== '0') {
+      hasAutoRun.current = true;
+      handleFindPath();
+    }
+  }, [formData.From, formData.To, formData.Amount, handleFindPath]);
+
   const noPathSuggestions = useMemo(() => {
     if (!pathData) return [];
     const hasNoPath = String(pathData?.maxFlow || '0') === '0' && (pathData?.transfers?.length || 0) === 0;
@@ -439,33 +457,42 @@ const FlowVisualization = () => {
       : [...normalizedFromTokens, normalized];
     const nextFromTokens = nextTokens.join(',');
 
+    const allTokens = Array.from(new Set(
+      (sourceBalances || [])
+        .map((row) => row?.tokenAddress?.toLowerCase())
+        .filter(Boolean)
+    ));
+    const excludedTokens = allTokens.filter(t => !nextTokens.includes(t));
+    const nextExcludedFromTokens = excludedTokens.join(',');
+
     setFromTokensIncludeValue(nextFromTokens);
 
-    if (quickFromFilterEnabled) {
+    if (quickFilterEnabled) {
       await executeFindPath({
         ...formData,
         FromTokens: nextFromTokens,
-        ExcludedFromTokens: '',
+        ExcludedFromTokens: nextExcludedFromTokens,
         IsFromTokensExcluded: false,
       });
     }
   }, [
     normalizedFromTokens,
+    sourceBalances,
     setFromTokensIncludeValue,
-    quickFromFilterEnabled,
+    quickFilterEnabled,
     executeFindPath,
     formData,
   ]);
 
   const toggleQuickFilterEnabled = useCallback(async () => {
-    const nextEnabled = !quickFromFilterEnabled;
-    setQuickFromFilterEnabled(nextEnabled);
+    const nextEnabled = !quickFilterEnabled;
+    setQuickFilterEnabled(nextEnabled);
     if (nextEnabled) {
       await executeFindPath(formData);
     }
   }, [
-    quickFromFilterEnabled,
-    setQuickFromFilterEnabled,
+    quickFilterEnabled,
+    setQuickFilterEnabled,
     executeFindPath,
     formData,
   ]);
@@ -486,7 +513,7 @@ const FlowVisualization = () => {
 
     setToTokensIncludeValue(nextToTokens);
 
-    if (quickToFilterEnabled) {
+    if (quickFilterEnabled) {
       await executeFindPath({
         ...formData,
         ToTokens: nextToTokens,
@@ -494,7 +521,7 @@ const FlowVisualization = () => {
         IsToTokensExcluded: false,
       });
     }
-  }, [sinkTrustRows, setToTokensIncludeValue, quickToFilterEnabled, executeFindPath, formData]);
+  }, [sinkTrustRows, setToTokensIncludeValue, quickFilterEnabled, executeFindPath, formData]);
 
   const toggleSelectAllSinkQuickTokens = useCallback(async () => {
     const allTokenAddresses = Array.from(new Set(
@@ -518,7 +545,7 @@ const FlowVisualization = () => {
 
     setToTokensIncludeValue(nextToTokens);
 
-    if (quickToFilterEnabled) {
+    if (quickFilterEnabled) {
       await executeFindPath({
         ...formData,
         ToTokens: nextToTokens,
@@ -529,27 +556,14 @@ const FlowVisualization = () => {
   }, [
     normalizedToTokens,
     setToTokensIncludeValue,
-    quickToFilterEnabled,
-    executeFindPath,
-    formData,
-  ]);
-
-  const toggleQuickToFilterEnabled = useCallback(async () => {
-    const nextEnabled = !quickToFilterEnabled;
-    setQuickToFilterEnabled(nextEnabled);
-    if (nextEnabled) {
-      await executeFindPath(formData);
-    }
-  }, [
-    quickToFilterEnabled,
-    setQuickToFilterEnabled,
+    quickFilterEnabled,
     executeFindPath,
     formData,
   ]);
 
   const clearQuickFilterSelection = useCallback(async () => {
     setFromTokensIncludeValue('');
-    if (quickFromFilterEnabled) {
+    if (quickFilterEnabled) {
       await executeFindPath({
         ...formData,
         FromTokens: '',
@@ -559,7 +573,7 @@ const FlowVisualization = () => {
     }
   }, [
     setFromTokensIncludeValue,
-    quickFromFilterEnabled,
+    quickFilterEnabled,
     executeFindPath,
     formData,
   ]);
@@ -1078,6 +1092,7 @@ const FlowVisualization = () => {
                                 className="text-xs"
                               >
                                 Source balances ({sortedSourceBalances.length})
+                                <InfoTip text="Tokens the sender holds. Select tokens to constrain which ones the pathfinder can spend (first hop)." size={12} />
                               </TabsTrigger>
                               <TabsTrigger
                                 isActive={lowerPanelTab === 'sink'}
@@ -1085,6 +1100,7 @@ const FlowVisualization = () => {
                                 className="text-xs"
                               >
                                 Sink trust ({sinkTrustRows.length})
+                                <InfoTip text="Avatars the receiver trusts. Select to constrain which token owners the receiver accepts (last hop). Independent from source balances — intermediaries bridge trust gaps." size={12} />
                               </TabsTrigger>
                             </TabsList>
                           </div>
@@ -1096,13 +1112,14 @@ const FlowVisualization = () => {
                                   <button
                                     type="button"
                                     onClick={toggleQuickFilterEnabled}
+                                    title="When ON, selecting tokens automatically re-runs pathfinding with the current selection"
                                     className={`text-xs px-2 py-1 rounded border ${
-                                      quickFromFilterEnabled
+                                      quickFilterEnabled
                                         ? 'bg-blue-600 text-white border-blue-600'
                                         : 'bg-gray-100 text-gray-700 border-gray-300'
                                     }`}
                                   >
-                                    Quick filter {quickFromFilterEnabled ? 'ON' : 'OFF'}
+                                    Auto-search {quickFilterEnabled ? 'ON' : 'OFF'}
                                   </button>
                                   <span className="text-xs text-gray-500">
                                     {normalizedFromTokens.length} selected
@@ -1174,14 +1191,15 @@ const FlowVisualization = () => {
                                 <div className="flex items-center gap-2 flex-wrap">
                                   <button
                                     type="button"
-                                    onClick={toggleQuickToFilterEnabled}
+                                    onClick={toggleQuickFilterEnabled}
+                                    title="When ON, selecting tokens automatically re-runs pathfinding with the current selection"
                                     className={`text-xs px-2 py-1 rounded border ${
-                                      quickToFilterEnabled
+                                      quickFilterEnabled
                                         ? 'bg-blue-600 text-white border-blue-600'
                                         : 'bg-gray-100 text-gray-700 border-gray-300'
                                     }`}
                                   >
-                                    Quick filter {quickToFilterEnabled ? 'ON' : 'OFF'}
+                                    Auto-search {quickFilterEnabled ? 'ON' : 'OFF'}
                                   </button>
                                   <span className="text-xs text-gray-500">{normalizedToTokens.length} selected</span>
                                 </div>

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -1,5 +1,6 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { createPortal } from 'react-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -9,12 +10,56 @@ import InfoTip from '@/components/ui/info-tip';
 import { parseAddressList } from '@/services/circlesApi';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
+const BALANCES_GRID_COLUMNS = ['holder', 'token', 'amount', 'isWrapped', 'isStatic'];
+const TRUSTS_GRID_COLUMNS = ['truster', 'trustee'];
+const EMPTY_BALANCE_ROW = { holder: '', token: '', amount: '', isWrapped: false, isStatic: false };
+const EMPTY_TRUST_ROW = { truster: '', trustee: '' };
+
+const toGridText = (rows, columns) => rows
+  .map((row) => columns.map((column) => {
+    const value = row?.[column];
+    return typeof value === 'boolean' ? String(value) : `${value ?? ''}`;
+  }).join('\t'))
+  .join('\n');
+
+const parseBooleanCell = (value) => {
+  const normalized = (value || '').trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'y';
+};
+
+const parseGridText = (text, columns) => {
+  const lines = (text || '').replace(/\r/g, '').split('\n');
+
+  return lines
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const values = line.includes('\t')
+        ? line.split('\t')
+        : line.split(',');
+
+      return columns.reduce((acc, column, index) => {
+        const raw = (values[index] || '').trim();
+        if (column === 'isWrapped' || column === 'isStatic') {
+          acc[column] = parseBooleanCell(raw);
+        } else {
+          acc[column] = raw;
+        }
+        return acc;
+      }, {});
+    });
+};
+
 const PathFinderForm = ({
   formData,
+  formErrors,
+  formWarnings,
   handleInputChange,
   handleTokensChange,
   handleWithWrapToggle,
   handleStagingToggle,
+  handleQuantizedModeToggle,
+  handleDebugIntermediateToggle,
   handleFromTokensExclusionToggle,
   handleToTokensExclusionToggle,
   onFindPath,
@@ -30,6 +75,183 @@ const PathFinderForm = ({
 }) => {
   const fromTokensRef = useRef(null);
   const toTokensRef = useRef(null);
+  const [isSimulationEditorOpen, setIsSimulationEditorOpen] = useState(false);
+  const [simulationBalanceRows, setSimulationBalanceRows] = useState([]);
+  const [simulationTrustRows, setSimulationTrustRows] = useState([]);
+  const [simulationConsentedRows, setSimulationConsentedRows] = useState([]);
+
+  const parsedSimulatedBalances = useMemo(() => {
+    try {
+      const parsed = JSON.parse(formData.SimulatedBalances || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }, [formData.SimulatedBalances]);
+
+  const parsedSimulatedTrusts = useMemo(() => {
+    try {
+      const parsed = JSON.parse(formData.SimulatedTrusts || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }, [formData.SimulatedTrusts]);
+
+  const openSimulationEditor = () => {
+    setSimulationBalanceRows(parsedSimulatedBalances.map((row) => ({
+      holder: `${row?.holder || ''}`,
+      token: `${row?.token || ''}`,
+      amount: `${row?.amount || ''}`,
+      isWrapped: Boolean(row?.isWrapped),
+      isStatic: Boolean(row?.isStatic),
+    })));
+    setSimulationTrustRows(parsedSimulatedTrusts.map((row) => ({
+      truster: `${row?.truster || ''}`,
+      trustee: `${row?.trustee || ''}`,
+    })));
+    setSimulationConsentedRows(parseAddressList(formData.SimulatedConsentedAvatars));
+    setIsSimulationEditorOpen(true);
+  };
+
+  const closeSimulationEditor = () => {
+    setIsSimulationEditorOpen(false);
+  };
+
+  const updateBalanceRow = (index, field, value) => {
+    setSimulationBalanceRows((prev) => prev.map((row, rowIndex) => (
+      rowIndex === index ? { ...row, [field]: value } : row
+    )));
+  };
+
+  const updateTrustRow = (index, field, value) => {
+    setSimulationTrustRows((prev) => prev.map((row, rowIndex) => (
+      rowIndex === index ? { ...row, [field]: value } : row
+    )));
+  };
+
+  const updateConsentedRow = (index, value) => {
+    setSimulationConsentedRows((prev) => prev.map((row, rowIndex) => (
+      rowIndex === index ? value : row
+    )));
+  };
+
+  const appendEmptyBalanceRow = () => {
+    setSimulationBalanceRows((prev) => [...prev, { ...EMPTY_BALANCE_ROW }]);
+  };
+
+  const appendEmptyTrustRow = () => {
+    setSimulationTrustRows((prev) => [...prev, { ...EMPTY_TRUST_ROW }]);
+  };
+
+  const appendEmptyConsentedRow = () => {
+    setSimulationConsentedRows((prev) => [...prev, '']);
+  };
+
+  const removeBalanceRow = (index) => {
+    setSimulationBalanceRows((prev) => prev.filter((_, rowIndex) => rowIndex !== index));
+  };
+
+  const removeTrustRow = (index) => {
+    setSimulationTrustRows((prev) => prev.filter((_, rowIndex) => rowIndex !== index));
+  };
+
+  const removeConsentedRow = (index) => {
+    setSimulationConsentedRows((prev) => prev.filter((_, rowIndex) => rowIndex !== index));
+  };
+
+  const saveSimulationEditor = () => {
+    const cleanedBalances = simulationBalanceRows
+      .map((row) => ({
+        holder: (row.holder || '').trim(),
+        token: (row.token || '').trim(),
+        amount: (row.amount || '').trim(),
+        isWrapped: Boolean(row.isWrapped),
+        isStatic: Boolean(row.isStatic),
+      }))
+      .filter((row) => row.holder || row.token || row.amount);
+
+    const cleanedTrusts = simulationTrustRows
+      .map((row) => ({
+        truster: (row.truster || '').trim(),
+        trustee: (row.trustee || '').trim(),
+      }))
+      .filter((row) => row.truster || row.trustee);
+
+    const cleanedConsentedAvatars = parseAddressList(simulationConsentedRows.join(','));
+
+    handleInputChange({
+      target: {
+        name: 'SimulatedBalances',
+        value: JSON.stringify(cleanedBalances),
+      }
+    });
+    handleInputChange({
+      target: {
+        name: 'SimulatedTrusts',
+        value: JSON.stringify(cleanedTrusts),
+      }
+    });
+    handleInputChange({
+      target: {
+        name: 'SimulatedConsentedAvatars',
+        value: cleanedConsentedAvatars.join(','),
+      }
+    });
+    closeSimulationEditor();
+  };
+
+  const normalizeSimulationGridText = () => {
+    const normalizedBalances = parseGridText(toGridText(simulationBalanceRows, BALANCES_GRID_COLUMNS), BALANCES_GRID_COLUMNS)
+      .map((row) => ({
+        holder: (row.holder || '').trim(),
+        token: (row.token || '').trim(),
+        amount: (row.amount || '').trim(),
+        isWrapped: Boolean(row.isWrapped),
+        isStatic: Boolean(row.isStatic),
+      }))
+      .filter((row) => row.holder || row.token || row.amount);
+
+    const normalizedTrusts = parseGridText(toGridText(simulationTrustRows, TRUSTS_GRID_COLUMNS), TRUSTS_GRID_COLUMNS)
+      .map((row) => ({
+        truster: (row.truster || '').trim(),
+        trustee: (row.trustee || '').trim(),
+      }))
+      .filter((row) => row.truster || row.trustee);
+
+    const normalizedConsented = parseAddressList(simulationConsentedRows.join(','));
+
+    setSimulationBalanceRows(normalizedBalances);
+    setSimulationTrustRows(normalizedTrusts);
+    setSimulationConsentedRows(normalizedConsented);
+  };
+
+  useEffect(() => {
+    if (!isSimulationEditorOpen) {
+      return undefined;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeSimulationEditor();
+      }
+
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        saveSimulationEditor();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [isSimulationEditorOpen, simulationBalanceRows, simulationTrustRows, simulationConsentedRows]);
 
   const handleFindPath = () => {
     // Auto-add any typed-but-not-submitted tokens, then pass patched formData
@@ -136,6 +358,22 @@ const PathFinderForm = ({
           />
           <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: staging.circlesubi.network\n\nCurrently using: ${formData.UseStaging ? 'staging.circlesubi.network' : 'rpc.aboutcircles.com'}`} />
         </div>
+        <div className="flex items-center">
+          <ToggleSwitch
+            isEnabled={formData.QuantizedMode}
+            onToggle={handleQuantizedModeToggle}
+            label="Quantized Mode"
+          />
+          <InfoTip text="Enable 96 CRC quantization semantics in the pathfinder." />
+        </div>
+        <div className="flex items-center">
+          <ToggleSwitch
+            isEnabled={formData.DebugShowIntermediateSteps}
+            onToggle={handleDebugIntermediateToggle}
+            label="Debug Intermediate Steps"
+          />
+          <InfoTip text="Request intermediate debug details from pathfinder when supported by the backend." />
+        </div>
         <div>
           <label className="block text-sm font-medium mb-1">Max Transfers</label>
           <Input
@@ -146,6 +384,54 @@ const PathFinderForm = ({
             type="number"
           />
         </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium mb-1">
+            Simulations
+            <InfoTip text="Open an editor with dedicated grids for simulated balances and simulated trusts." />
+          </label>
+          <div className="rounded-md border border-input p-3 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs text-muted-foreground">
+                Balances: {parsedSimulatedBalances.length} · Trusts: {parsedSimulatedTrusts.length}
+              </div>
+              <Button type="button" onClick={openSimulationEditor}>Edit simulations</Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Use the popup grid editor to manage rows. Data is stored as canonical JSON arrays in form state.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Consented avatars can also be edited in the same popup.
+            </p>
+          </div>
+          {formErrors?.SimulatedBalances && <p className="text-xs text-red-600">{formErrors.SimulatedBalances}</p>}
+          {formErrors?.SimulatedTrusts && <p className="text-xs text-red-600">{formErrors.SimulatedTrusts}</p>}
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Simulated Consented Avatars
+            <InfoTip text='Comma/space separated avatar addresses.' />
+          </label>
+          <Input
+            name="SimulatedConsentedAvatars"
+            value={formData.SimulatedConsentedAvatars}
+            onChange={handleInputChange}
+            placeholder="0x...,0x..."
+          />
+          {formErrors?.SimulatedConsentedAvatars && <p className="mt-1 text-xs text-red-600">{formErrors.SimulatedConsentedAvatars}</p>}
+        </div>
+
+        {(formErrors?.From || formErrors?.To || formErrors?.Amount) && (
+          <p className="text-xs text-red-600">
+            {formErrors.From || formErrors.To || formErrors.Amount}
+          </p>
+        )}
+        {Array.isArray(formWarnings) && formWarnings.length > 0 && (
+          <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2 space-y-1">
+            {formWarnings.map((warning, index) => (
+              <p key={`${warning}-${index}`}>{warning}</p>
+            ))}
+          </div>
+        )}
 
         {pathData && (
           <div className="mb-4">
@@ -190,6 +476,131 @@ const PathFinderForm = ({
         >
           {isLoading ? 'Finding Path...' : 'Find Path'}
         </Button>
+
+        {isSimulationEditorOpen && typeof document !== 'undefined' && createPortal(
+          <div
+            className="fixed inset-0 z-[1000] bg-slate-950/65 backdrop-blur-[2px] p-4 sm:p-6"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="simulation-editor-title"
+            onClick={(event) => {
+              if (event.target === event.currentTarget) {
+                closeSimulationEditor();
+              }
+            }}
+          >
+            <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-center">
+              <div className="flex h-[min(900px,calc(100vh-2rem))] w-full flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl sm:h-[min(900px,calc(100vh-3rem))]">
+                <div className="flex items-start justify-between gap-4 border-b bg-muted/30 px-5 py-4">
+                  <div className="space-y-1">
+                    <h3 id="simulation-editor-title" className="text-base font-semibold tracking-tight">Simulation Editor</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Edit simulated balances, trusts, and consented avatars in a structured data grid.
+                    </p>
+                  </div>
+                  <Button type="button" className="h-8 px-3" onClick={closeSimulationEditor}>Close</Button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto p-4 sm:p-5">
+                  <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+                    <div className="overflow-hidden rounded-xl border bg-card">
+                      <div className="flex items-center justify-between border-b px-4 py-3">
+                        <h4 className="text-sm font-semibold">Simulated Balances</h4>
+                        <Button type="button" className="h-8 px-3" onClick={appendEmptyBalanceRow}>Add row</Button>
+                      </div>
+                      <div className="space-y-3 p-4">
+                        <div className="grid grid-cols-[1fr_1fr_1fr_88px_72px_86px] gap-2 rounded-md border bg-muted/40 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          <span>holder</span>
+                          <span>token</span>
+                          <span>amount</span>
+                          <span>wrapped</span>
+                          <span>static</span>
+                          <span className="text-right">action</span>
+                        </div>
+                        <div className="max-h-[48vh] space-y-2 overflow-y-auto pr-1">
+                          {simulationBalanceRows.map((row, index) => (
+                            <div key={`balance-row-${index}`} className="grid grid-cols-[1fr_1fr_1fr_88px_72px_86px] gap-2 rounded-md border border-transparent bg-muted/10 p-1.5 hover:border-border hover:bg-muted/20">
+                              <Input value={row.holder} onChange={(event) => updateBalanceRow(index, 'holder', event.target.value)} placeholder="0xholder" className="h-8 font-mono text-xs" />
+                              <Input value={row.token} onChange={(event) => updateBalanceRow(index, 'token', event.target.value)} placeholder="0xtoken" className="h-8 font-mono text-xs" />
+                              <Input value={row.amount} onChange={(event) => updateBalanceRow(index, 'amount', event.target.value)} placeholder="1000000000000000000" className="h-8 font-mono text-xs" />
+                              <label className="flex h-8 items-center justify-center gap-1 rounded-md border bg-background px-2 text-[11px] font-medium">
+                                <input type="checkbox" checked={Boolean(row.isWrapped)} onChange={(event) => updateBalanceRow(index, 'isWrapped', event.target.checked)} />
+                                yes
+                              </label>
+                              <label className="flex h-8 items-center justify-center gap-1 rounded-md border bg-background px-2 text-[11px] font-medium">
+                                <input type="checkbox" checked={Boolean(row.isStatic)} onChange={(event) => updateBalanceRow(index, 'isStatic', event.target.checked)} />
+                                yes
+                              </label>
+                              <Button type="button" className="h-8 px-2 text-xs" onClick={() => removeBalanceRow(index)}>Remove</Button>
+                            </div>
+                          ))}
+                        </div>
+                        <p className="text-[11px] text-muted-foreground">One editable row per simulated balance.</p>
+                      </div>
+                    </div>
+
+                    <div className="overflow-hidden rounded-xl border bg-card">
+                      <div className="flex items-center justify-between border-b px-4 py-3">
+                        <h4 className="text-sm font-semibold">Simulated Trusts</h4>
+                        <Button type="button" className="h-8 px-3" onClick={appendEmptyTrustRow}>Add row</Button>
+                      </div>
+                      <div className="space-y-3 p-4">
+                        <div className="grid grid-cols-[1fr_1fr_86px] gap-2 rounded-md border bg-muted/40 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          <span>truster</span>
+                          <span>trustee</span>
+                          <span className="text-right">action</span>
+                        </div>
+                        <div className="max-h-[48vh] space-y-2 overflow-y-auto pr-1">
+                          {simulationTrustRows.map((row, index) => (
+                            <div key={`trust-row-${index}`} className="grid grid-cols-[1fr_1fr_86px] gap-2 rounded-md border border-transparent bg-muted/10 p-1.5 hover:border-border hover:bg-muted/20">
+                              <Input value={row.truster} onChange={(event) => updateTrustRow(index, 'truster', event.target.value)} placeholder="0xtruster" className="h-8 font-mono text-xs" />
+                              <Input value={row.trustee} onChange={(event) => updateTrustRow(index, 'trustee', event.target.value)} placeholder="0xtrustee" className="h-8 font-mono text-xs" />
+                              <Button type="button" className="h-8 px-2 text-xs" onClick={() => removeTrustRow(index)}>Remove</Button>
+                            </div>
+                          ))}
+                        </div>
+                        <p className="text-[11px] text-muted-foreground">One editable row per trust edge.</p>
+                      </div>
+                    </div>
+
+                    <div className="overflow-hidden rounded-xl border bg-card">
+                      <div className="flex items-center justify-between border-b px-4 py-3">
+                        <h4 className="text-sm font-semibold">Simulated Consented Avatars</h4>
+                        <Button type="button" className="h-8 px-3" onClick={appendEmptyConsentedRow}>Add row</Button>
+                      </div>
+                      <div className="space-y-3 p-4">
+                        <div className="grid grid-cols-[1fr_86px] gap-2 rounded-md border bg-muted/40 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          <span>avatar</span>
+                          <span className="text-right">action</span>
+                        </div>
+                        <div className="max-h-[48vh] space-y-2 overflow-y-auto pr-1">
+                          {simulationConsentedRows.map((row, index) => (
+                            <div key={`consented-row-${index}`} className="grid grid-cols-[1fr_86px] gap-2 rounded-md border border-transparent bg-muted/10 p-1.5 hover:border-border hover:bg-muted/20">
+                              <Input value={row} onChange={(event) => updateConsentedRow(index, event.target.value)} placeholder="0xavatar" className="h-8 font-mono text-xs" />
+                              <Button type="button" className="h-8 px-2 text-xs" onClick={() => removeConsentedRow(index)}>Remove</Button>
+                            </div>
+                          ))}
+                        </div>
+                        <p className="text-[11px] text-muted-foreground">One editable row per consented avatar.</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t bg-muted/20 px-5 py-3">
+                  <div className="text-xs text-muted-foreground">Shortcuts: Ctrl/Cmd+Enter = Apply, Esc = Cancel</div>
+                  <div className="flex items-center gap-2">
+                    <Button type="button" className="h-8 px-3" onClick={normalizeSimulationGridText}>Normalize</Button>
+                    <Button type="button" className="h-8 px-3" onClick={() => { setSimulationBalanceRows([]); setSimulationTrustRows([]); setSimulationConsentedRows([]); }}>Clear</Button>
+                    <Button type="button" className="h-8 px-3" onClick={closeSimulationEditor}>Cancel</Button>
+                    <Button type="button" className="h-8 px-4" onClick={saveSimulationEditor}>Apply</Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
       </CardContent>
     </Card>
   );
@@ -209,11 +620,20 @@ PathFinderForm.propTypes = {
     MaxTransfers: PropTypes.string,
     IsFromTokensExcluded: PropTypes.bool.isRequired,
     IsToTokensExcluded: PropTypes.bool.isRequired,
+    QuantizedMode: PropTypes.bool.isRequired,
+    DebugShowIntermediateSteps: PropTypes.bool.isRequired,
+    SimulatedBalances: PropTypes.string.isRequired,
+    SimulatedTrusts: PropTypes.string.isRequired,
+    SimulatedConsentedAvatars: PropTypes.string.isRequired,
   }).isRequired,
+  formErrors: PropTypes.object,
+  formWarnings: PropTypes.arrayOf(PropTypes.string),
   handleInputChange: PropTypes.func.isRequired,
   handleTokensChange: PropTypes.func.isRequired,
   handleWithWrapToggle: PropTypes.func.isRequired,
   handleStagingToggle: PropTypes.func.isRequired,
+  handleQuantizedModeToggle: PropTypes.func.isRequired,
+  handleDebugIntermediateToggle: PropTypes.func.isRequired,
   handleFromTokensExclusionToggle: PropTypes.func.isRequired,
   handleToTokensExclusionToggle: PropTypes.func.isRequired,
   onFindPath: PropTypes.func.isRequired,

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -358,21 +358,21 @@ const PathFinderForm = ({
           />
           <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: staging.circlesubi.network\n\nCurrently using: ${formData.UseStaging ? 'staging.circlesubi.network' : 'rpc.aboutcircles.com'}`} />
         </div>
-        <div className="flex items-center">
+        <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
           <ToggleSwitch
             isEnabled={formData.QuantizedMode}
             onToggle={handleQuantizedModeToggle}
             label="Quantized Mode"
           />
-          <InfoTip text="Enable 96 CRC quantization semantics in the pathfinder." />
+          <InfoTip text="Not yet supported — awaiting SDK update. Will enable 96 CRC quantization semantics." />
         </div>
-        <div className="flex items-center">
+        <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
           <ToggleSwitch
             isEnabled={formData.DebugShowIntermediateSteps}
             onToggle={handleDebugIntermediateToggle}
             label="Debug Intermediate Steps"
           />
-          <InfoTip text="Request intermediate debug details from pathfinder when supported by the backend." />
+          <InfoTip text="Not yet supported — awaiting SDK update. Will request intermediate debug details from pathfinder." />
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Max Transfers</label>
@@ -391,31 +391,29 @@ const PathFinderForm = ({
           </label>
           <div className="rounded-md border border-input p-3 space-y-2">
             <div className="flex items-center justify-between gap-2">
-              <div className="text-xs text-muted-foreground">
+              <div className="text-xs text-gray-500">
                 Balances: {parsedSimulatedBalances.length} · Trusts: {parsedSimulatedTrusts.length}
               </div>
               <Button type="button" onClick={openSimulationEditor}>Edit simulations</Button>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Use the popup grid editor to manage rows. Data is stored as canonical JSON arrays in form state.
-            </p>
-            <p className="text-xs text-muted-foreground">
-              Consented avatars can also be edited in the same popup.
+            <p className="text-xs text-gray-500">
+              Edit simulated balances and trusts for hypothetical pathfinding scenarios.
             </p>
           </div>
           {formErrors?.SimulatedBalances && <p className="text-xs text-red-600">{formErrors.SimulatedBalances}</p>}
           {formErrors?.SimulatedTrusts && <p className="text-xs text-red-600">{formErrors.SimulatedTrusts}</p>}
         </div>
-        <div>
+        <div className="opacity-40 pointer-events-none" title="Not yet supported by SDK">
           <label className="block text-sm font-medium mb-1">
             Simulated Consented Avatars
-            <InfoTip text='Comma/space separated avatar addresses.' />
+            <InfoTip text='Not yet supported — awaiting SDK update. Will accept comma/space separated avatar addresses.' />
           </label>
           <Input
             name="SimulatedConsentedAvatars"
             value={formData.SimulatedConsentedAvatars}
             onChange={handleInputChange}
             placeholder="0x...,0x..."
+            disabled
           />
           {formErrors?.SimulatedConsentedAvatars && <p className="mt-1 text-xs text-red-600">{formErrors.SimulatedConsentedAvatars}</p>}
         </div>
@@ -490,12 +488,12 @@ const PathFinderForm = ({
             }}
           >
             <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-center">
-              <div className="flex h-[min(900px,calc(100vh-2rem))] w-full flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl sm:h-[min(900px,calc(100vh-3rem))]">
-                <div className="flex items-start justify-between gap-4 border-b bg-muted/30 px-5 py-4">
+              <div className="flex h-[min(900px,calc(100vh-2rem))] w-full flex-col overflow-hidden rounded-2xl border bg-white shadow-2xl sm:h-[min(900px,calc(100vh-3rem))]">
+                <div className="flex items-start justify-between gap-4 border-b bg-gray-50 px-5 py-4">
                   <div className="space-y-1">
                     <h3 id="simulation-editor-title" className="text-base font-semibold tracking-tight">Simulation Editor</h3>
-                    <p className="text-xs text-muted-foreground">
-                      Edit simulated balances, trusts, and consented avatars in a structured data grid.
+                    <p className="text-xs text-gray-500">
+                      Edit simulated balances and trusts in a structured data grid.
                     </p>
                   </div>
                   <Button type="button" className="h-8 px-3" onClick={closeSimulationEditor}>Close</Button>
@@ -503,13 +501,13 @@ const PathFinderForm = ({
 
                 <div className="flex-1 overflow-y-auto p-4 sm:p-5">
                   <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
-                    <div className="overflow-hidden rounded-xl border bg-card">
+                    <div className="overflow-hidden rounded-xl border bg-white">
                       <div className="flex items-center justify-between border-b px-4 py-3">
                         <h4 className="text-sm font-semibold">Simulated Balances</h4>
                         <Button type="button" className="h-8 px-3" onClick={appendEmptyBalanceRow}>Add row</Button>
                       </div>
                       <div className="space-y-3 p-4">
-                        <div className="grid grid-cols-[1fr_1fr_1fr_88px_72px_86px] gap-2 rounded-md border bg-muted/40 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        <div className="grid grid-cols-[1fr_1fr_1fr_60px_52px_64px] gap-2 rounded-md border bg-gray-100 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
                           <span>holder</span>
                           <span>token</span>
                           <span>amount</span>
@@ -519,15 +517,15 @@ const PathFinderForm = ({
                         </div>
                         <div className="max-h-[48vh] space-y-2 overflow-y-auto pr-1">
                           {simulationBalanceRows.map((row, index) => (
-                            <div key={`balance-row-${index}`} className="grid grid-cols-[1fr_1fr_1fr_88px_72px_86px] gap-2 rounded-md border border-transparent bg-muted/10 p-1.5 hover:border-border hover:bg-muted/20">
+                            <div key={`balance-row-${index}`} className="grid grid-cols-[1fr_1fr_1fr_60px_52px_64px] gap-2 rounded-md border border-transparent bg-gray-50/50 p-1.5 hover:border-gray-200 hover:bg-gray-50">
                               <Input value={row.holder} onChange={(event) => updateBalanceRow(index, 'holder', event.target.value)} placeholder="0xholder" className="h-8 font-mono text-xs" />
                               <Input value={row.token} onChange={(event) => updateBalanceRow(index, 'token', event.target.value)} placeholder="0xtoken" className="h-8 font-mono text-xs" />
                               <Input value={row.amount} onChange={(event) => updateBalanceRow(index, 'amount', event.target.value)} placeholder="1000000000000000000" className="h-8 font-mono text-xs" />
-                              <label className="flex h-8 items-center justify-center gap-1 rounded-md border bg-background px-2 text-[11px] font-medium">
+                              <label className="flex h-8 items-center justify-center gap-1 rounded-md border bg-white px-2 text-[11px] font-medium">
                                 <input type="checkbox" checked={Boolean(row.isWrapped)} onChange={(event) => updateBalanceRow(index, 'isWrapped', event.target.checked)} />
                                 yes
                               </label>
-                              <label className="flex h-8 items-center justify-center gap-1 rounded-md border bg-background px-2 text-[11px] font-medium">
+                              <label className="flex h-8 items-center justify-center gap-1 rounded-md border bg-white px-2 text-[11px] font-medium">
                                 <input type="checkbox" checked={Boolean(row.isStatic)} onChange={(event) => updateBalanceRow(index, 'isStatic', event.target.checked)} />
                                 yes
                               </label>
@@ -535,60 +533,60 @@ const PathFinderForm = ({
                             </div>
                           ))}
                         </div>
-                        <p className="text-[11px] text-muted-foreground">One editable row per simulated balance.</p>
+                        <p className="text-[11px] text-gray-500">One editable row per simulated balance.</p>
                       </div>
                     </div>
 
-                    <div className="overflow-hidden rounded-xl border bg-card">
+                    <div className="overflow-hidden rounded-xl border bg-white">
                       <div className="flex items-center justify-between border-b px-4 py-3">
                         <h4 className="text-sm font-semibold">Simulated Trusts</h4>
                         <Button type="button" className="h-8 px-3" onClick={appendEmptyTrustRow}>Add row</Button>
                       </div>
                       <div className="space-y-3 p-4">
-                        <div className="grid grid-cols-[1fr_1fr_86px] gap-2 rounded-md border bg-muted/40 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        <div className="grid grid-cols-[1fr_1fr_86px] gap-2 rounded-md border bg-gray-100 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
                           <span>truster</span>
                           <span>trustee</span>
                           <span className="text-right">action</span>
                         </div>
                         <div className="max-h-[48vh] space-y-2 overflow-y-auto pr-1">
                           {simulationTrustRows.map((row, index) => (
-                            <div key={`trust-row-${index}`} className="grid grid-cols-[1fr_1fr_86px] gap-2 rounded-md border border-transparent bg-muted/10 p-1.5 hover:border-border hover:bg-muted/20">
+                            <div key={`trust-row-${index}`} className="grid grid-cols-[1fr_1fr_86px] gap-2 rounded-md border border-transparent bg-gray-50/50 p-1.5 hover:border-gray-200 hover:bg-gray-50">
                               <Input value={row.truster} onChange={(event) => updateTrustRow(index, 'truster', event.target.value)} placeholder="0xtruster" className="h-8 font-mono text-xs" />
                               <Input value={row.trustee} onChange={(event) => updateTrustRow(index, 'trustee', event.target.value)} placeholder="0xtrustee" className="h-8 font-mono text-xs" />
                               <Button type="button" className="h-8 px-2 text-xs" onClick={() => removeTrustRow(index)}>Remove</Button>
                             </div>
                           ))}
                         </div>
-                        <p className="text-[11px] text-muted-foreground">One editable row per trust edge.</p>
+                        <p className="text-[11px] text-gray-500">One editable row per trust edge.</p>
                       </div>
                     </div>
 
-                    <div className="overflow-hidden rounded-xl border bg-card">
+                    <div className="overflow-hidden rounded-xl border bg-white opacity-40 pointer-events-none">
                       <div className="flex items-center justify-between border-b px-4 py-3">
-                        <h4 className="text-sm font-semibold">Simulated Consented Avatars</h4>
+                        <h4 className="text-sm font-semibold">Simulated Consented Avatars <span className="text-xs font-normal text-gray-500">(not yet supported by SDK)</span></h4>
                         <Button type="button" className="h-8 px-3" onClick={appendEmptyConsentedRow}>Add row</Button>
                       </div>
                       <div className="space-y-3 p-4">
-                        <div className="grid grid-cols-[1fr_86px] gap-2 rounded-md border bg-muted/40 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        <div className="grid grid-cols-[1fr_86px] gap-2 rounded-md border bg-gray-100 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
                           <span>avatar</span>
                           <span className="text-right">action</span>
                         </div>
                         <div className="max-h-[48vh] space-y-2 overflow-y-auto pr-1">
                           {simulationConsentedRows.map((row, index) => (
-                            <div key={`consented-row-${index}`} className="grid grid-cols-[1fr_86px] gap-2 rounded-md border border-transparent bg-muted/10 p-1.5 hover:border-border hover:bg-muted/20">
+                            <div key={`consented-row-${index}`} className="grid grid-cols-[1fr_86px] gap-2 rounded-md border border-transparent bg-gray-50/50 p-1.5 hover:border-gray-200 hover:bg-gray-50">
                               <Input value={row} onChange={(event) => updateConsentedRow(index, event.target.value)} placeholder="0xavatar" className="h-8 font-mono text-xs" />
                               <Button type="button" className="h-8 px-2 text-xs" onClick={() => removeConsentedRow(index)}>Remove</Button>
                             </div>
                           ))}
                         </div>
-                        <p className="text-[11px] text-muted-foreground">One editable row per consented avatar.</p>
+                        <p className="text-[11px] text-gray-500">One editable row per consented avatar.</p>
                       </div>
                     </div>
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center justify-between gap-3 border-t bg-muted/20 px-5 py-3">
-                  <div className="text-xs text-muted-foreground">Shortcuts: Ctrl/Cmd+Enter = Apply, Esc = Cancel</div>
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t bg-gray-50 px-5 py-3">
+                  <div className="text-xs text-gray-500">Shortcuts: Ctrl/Cmd+Enter = Apply, Esc = Cancel</div>
                   <div className="flex items-center gap-2">
                     <Button type="button" className="h-8 px-3" onClick={normalizeSimulationGridText}>Normalize</Button>
                     <Button type="button" className="h-8 px-3" onClick={() => { setSimulationBalanceRows([]); setSimulationTrustRows([]); setSimulationConsentedRows([]); }}>Clear</Button>

--- a/src/components/ui/token-input.jsx
+++ b/src/components/ui/token-input.jsx
@@ -89,6 +89,16 @@ const TokenInput = forwardRef(({ value, onChange, placeholder, label, isExcluded
       </div>
       {tokens.length > 0 && (
         <div className="flex flex-wrap gap-2 mt-2">
+          {tokens.length > 1 && (
+            <button
+              type="button"
+              className="flex items-center rounded-md px-2 py-1 bg-red-50 text-red-600 hover:bg-red-100 text-xs font-medium"
+              onClick={() => onChange('')}
+            >
+              Clear all ({tokens.length})
+              <X size={14} className="ml-1" />
+            </button>
+          )}
           {tokens.map((token, index) => (
             <div key={index} className={`flex items-center rounded-md px-2 py-1 ${isExcluded ? 'bg-red-100' : 'bg-gray-100'}`}>
               <span className="text-xs font-mono mr-1 truncate" style={{maxWidth: '120px'}}>

--- a/src/config/wagmi.js
+++ b/src/config/wagmi.js
@@ -73,7 +73,13 @@ const createConnectors = () => {
 }
 
 export const config = createConfig({
-  chains: [gnosis],
+  chains: [{
+    ...gnosis,
+    rpcUrls: {
+      public: { http: ['https://rpc.aboutcircles.com'] },
+      default: { http: ['https://rpc.aboutcircles.com'] },
+    },
+  }],
   connectors: createConnectors(),
   transports: {
     [gnosis.id]: http(),

--- a/src/hooks/useCytoscape.js
+++ b/src/hooks/useCytoscape.js
@@ -30,14 +30,20 @@ export const useCytoscape = ({
   const cyRef = useRef(null);
   const isInitializingRef = useRef(false);
   const onNodeRemoveRef = useRef(onNodeRemove);
+  const nodeProfilesRef = useRef(nodeProfiles);
+  const tokenOwnerProfilesRef = useRef(tokenOwnerProfiles);
+  const balancesByAccountRef = useRef(balancesByAccount);
   onNodeRemoveRef.current = onNodeRemove;
+  nodeProfilesRef.current = nodeProfiles;
+  tokenOwnerProfilesRef.current = tokenOwnerProfiles;
+  balancesByAccountRef.current = balancesByAccount;
   const { config, updateStats } = usePerformance();
   const normalizeAddress = (value) => (typeof value === 'string' ? value.toLowerCase() : '');
   const getBalanceEntryForTransfer = (data) => {
     const srcAddr = normalizeAddress(data?.source);
     if (!srcAddr) return null;
 
-    const balanceMap = balancesByAccount[srcAddr] || {};
+    const balanceMap = balancesByAccountRef.current[srcAddr] || {};
     const candidates = [
       data?.tokenAddress,
       data?.tokenOwner,
@@ -343,10 +349,13 @@ export const useCytoscape = ({
       styles.push({
         selector: '.highlighted',
         style: {
-          'line-color': '#2563EB',
-          'target-arrow-color': '#2563EB',
+          // Keep original edge color/gradient (important for Ultra "usage bar")
+          // and add emphasis via thickness + overlay only.
           'width': 3,
-          'z-index': 999
+          'z-index': 999,
+          'overlay-opacity': 0.25,
+          'overlay-color': '#2563EB',
+          'overlay-padding': 2
         }
       });
 
@@ -502,8 +511,8 @@ export const useCytoscape = ({
             const node = event.target;
             const position = event.renderedPosition;
             const addr = node.id();
-            const profile = nodeProfiles[addr];
-            const balanceMap = balancesByAccount[addr] || {};
+            const profile = nodeProfilesRef.current[addr];
+            const balanceMap = balancesByAccountRef.current[addr] || {};
             const totalCrc = Object.values(balanceMap).reduce((sum, e) => sum + (e.crc || 0), 0);
             
             let tooltipText = '';
@@ -545,7 +554,7 @@ export const useCytoscape = ({
             }
             
             if (data.tokenOwner) {
-              const tokenProfile = tokenOwnerProfiles[data.tokenOwner];
+              const tokenProfile = tokenOwnerProfilesRef.current[data.tokenOwner];
               if (tokenProfile?.name) {
                 tooltipText += `Token Owner: ${tokenProfile.name}\n`;
               }
@@ -646,7 +655,7 @@ export const useCytoscape = ({
       isInitializingRef.current = false;
     }
 
-  }, [pathData, rawPathData, formData, wrappedTokens, tokenInfo, edgeCatalogByIndex, config.rendering.features, config.rendering.fastMode, updateStats, nodeProfiles, tokenOwnerProfiles, balancesByAccount, onTooltip, onTransactionSelect, layoutName]);
+  }, [pathData, rawPathData, formData, wrappedTokens, tokenInfo, edgeCatalogByIndex, config.rendering.features, config.rendering.fastMode, updateStats, onTooltip, onTransactionSelect]);
 
   // Update edge styles when config changes
   useEffect(() => {
@@ -774,7 +783,7 @@ export const useCytoscape = ({
         }
       });
     });
-  }, [balancesByAccount, config.rendering.features]);
+  }, [pathData, balancesByAccount, config.rendering.features]);
 
   // Edge filtering removed — slider now drives transfer selection upstream,
   // which changes the pathData prop, causing graph re-render with filtered data.

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -37,6 +37,36 @@ const DEFAULTS = {
   MaxTransfers: '10',
   IsFromTokensExcluded: false,
   IsToTokensExcluded: false,
+  QuantizedMode: false,
+  DebugShowIntermediateSteps: false,
+  SimulatedBalances: '[]',
+  SimulatedTrusts: '[]',
+  SimulatedConsentedAvatars: '',
+};
+
+const isAddress = (value) => typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value.trim());
+
+const parseTokenSet = (value) => new Set(
+  (value || '')
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+const hasDuplicates = (values) => {
+  const normalized = values
+    .map((value) => (typeof value === 'string' ? value.trim().toLowerCase() : ''))
+    .filter(Boolean);
+  return new Set(normalized).size !== normalized.length;
+};
+
+const parseJsonArray = (value) => {
+  try {
+    const parsed = JSON.parse(value || '[]');
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 };
 
 export const useFormData = () => {
@@ -176,6 +206,122 @@ export const useFormData = () => {
     }));
   };
 
+  const handleQuantizedModeToggle = () => {
+    setFormData(prev => ({
+      ...prev,
+      QuantizedMode: !prev.QuantizedMode
+    }));
+  };
+
+  const handleDebugIntermediateToggle = () => {
+    setFormData(prev => ({
+      ...prev,
+      DebugShowIntermediateSteps: !prev.DebugShowIntermediateSteps
+    }));
+  };
+
+  const validateFormData = useCallback((candidateFormData) => {
+    const nextErrors = {};
+    const nextWarnings = [];
+
+    if (!isAddress(candidateFormData?.From)) nextErrors.From = 'Source must be a valid 0x address';
+    if (!isAddress(candidateFormData?.To)) nextErrors.To = 'Sink must be a valid 0x address';
+
+    try {
+      const target = BigInt(candidateFormData?.Amount || '0');
+      if (target <= 0n) nextErrors.Amount = 'Target flow must be greater than 0';
+    } catch {
+      nextErrors.Amount = 'Target flow must be a valid uint value';
+    }
+
+    const simulatedBalances = parseJsonArray(candidateFormData?.SimulatedBalances);
+    if (!simulatedBalances) {
+      nextErrors.SimulatedBalances = 'Simulated balances must be a valid JSON array';
+    } else {
+      if (simulatedBalances.length > 200) {
+        nextErrors.SimulatedBalances = 'Too many simulated balances (max 200).';
+      } else {
+        const hasInvalidBalanceRow = simulatedBalances.some((entry) => {
+          const holderOk = isAddress(entry?.holder);
+          const tokenOk = isAddress(entry?.token);
+          let amountOk = false;
+          try {
+            const value = BigInt(entry?.amount ?? '');
+            amountOk = value >= 0n;
+          } catch {
+            amountOk = false;
+          }
+          return !(holderOk && tokenOk && amountOk);
+        });
+        if (hasInvalidBalanceRow) {
+          nextErrors.SimulatedBalances = 'Each simulated balance must include valid holder, token, and uint amount.';
+        } else if (hasDuplicates(simulatedBalances.map((entry) => `${entry?.holder}|${entry?.token}|${entry?.amount}|${entry?.isWrapped}|${entry?.isStatic}`))) {
+          nextWarnings.push('Simulated balances contain duplicate rows. Duplicates will be ignored by pathfinder semantics in most cases.');
+        }
+      }
+    }
+
+    const simulatedTrusts = parseJsonArray(candidateFormData?.SimulatedTrusts);
+    if (!simulatedTrusts) {
+      nextErrors.SimulatedTrusts = 'Simulated trusts must be a valid JSON array';
+    } else {
+      if (simulatedTrusts.length > 200) {
+        nextErrors.SimulatedTrusts = 'Too many simulated trusts (max 200).';
+      } else {
+        const hasInvalidTrustRow = simulatedTrusts.some((entry) => (
+          !isAddress(entry?.truster) || !isAddress(entry?.trustee)
+        ));
+        if (hasInvalidTrustRow) {
+          nextErrors.SimulatedTrusts = 'Each simulated trust must include valid truster and trustee addresses.';
+        } else if (hasDuplicates(simulatedTrusts.map((entry) => `${entry?.truster}|${entry?.trustee}`))) {
+          nextWarnings.push('Simulated trusts contain duplicate edges. Consider deduplicating for clearer results.');
+        }
+      }
+    }
+
+    const consentedAvatars = (candidateFormData?.SimulatedConsentedAvatars || '')
+      .split(/[\s,]+/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+    if (consentedAvatars.length > 200) {
+      nextErrors.SimulatedConsentedAvatars = 'Too many consented avatars (max 200).';
+    } else if (consentedAvatars.some((value) => !isAddress(value))) {
+      nextErrors.SimulatedConsentedAvatars = 'Consented avatars must be valid 0x addresses.';
+    } else if (hasDuplicates(consentedAvatars)) {
+      nextWarnings.push('Simulated consented avatars contain duplicates.');
+    }
+
+    const includeFromTokens = parseTokenSet(candidateFormData?.FromTokens);
+    const excludeFromTokens = parseTokenSet(candidateFormData?.ExcludedFromTokens);
+    const includeToTokens = parseTokenSet(candidateFormData?.ToTokens);
+    const excludeToTokens = parseTokenSet(candidateFormData?.ExcludedToTokens);
+
+    const fromConflict = [...includeFromTokens].some((token) => excludeFromTokens.has(token));
+    const toConflict = [...includeToTokens].some((token) => excludeToTokens.has(token));
+
+    if (fromConflict) nextWarnings.push('Some source tokens appear in both include and exclude lists.');
+    if (toConflict) nextWarnings.push('Some sink tokens appear in both include and exclude lists.');
+    if (hasDuplicates((candidateFormData?.FromTokens || '').split(','))) {
+      nextWarnings.push('Source token allowlist contains duplicates.');
+    }
+    if (hasDuplicates((candidateFormData?.ExcludedFromTokens || '').split(','))) {
+      nextWarnings.push('Source token exclusion list contains duplicates.');
+    }
+    if (hasDuplicates((candidateFormData?.ToTokens || '').split(','))) {
+      nextWarnings.push('Sink token allowlist contains duplicates.');
+    }
+    if (hasDuplicates((candidateFormData?.ExcludedToTokens || '').split(','))) {
+      nextWarnings.push('Sink token exclusion list contains duplicates.');
+    }
+
+    setFormErrors(nextErrors);
+    return {
+      isValid: Object.keys(nextErrors).length === 0,
+      warnings: nextWarnings,
+      errors: nextErrors,
+    };
+  }, []);
+
   const applyFormUpdates = useCallback((updatesOrUpdater) => {
     setFormData(prev => {
       if (typeof updatesOrUpdater === 'function') {
@@ -212,10 +358,13 @@ export const useFormData = () => {
     handleTokensChange,
     handleWithWrapToggle,
     handleStagingToggle,
+    handleQuantizedModeToggle,
+    handleDebugIntermediateToggle,
     handleFromTokensExclusionToggle,
     handleToTokensExclusionToggle,
     applyFormUpdates,
     setFromTokensIncludeValue,
     setToTokensIncludeValue,
+    validateFormData,
   };
 };

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -234,6 +234,13 @@ export const useFormData = () => {
       nextErrors.Amount = 'Target flow must be a valid uint value';
     }
 
+    if (candidateFormData?.MaxTransfers) {
+      const mt = Number(candidateFormData.MaxTransfers);
+      if (!Number.isInteger(mt) || mt < 1 || mt > 500) {
+        nextErrors.MaxTransfers = 'Max transfers must be an integer between 1 and 500';
+      }
+    }
+
     const simulatedBalances = parseJsonArray(candidateFormData?.SimulatedBalances);
     if (!simulatedBalances) {
       nextErrors.SimulatedBalances = 'Simulated balances must be a valid JSON array';

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -2,11 +2,13 @@ import { CirclesData, CirclesRpc as LegacyCirclesRpc } from "@circles-sdk/data";
 import { Profiles } from "@circles-sdk/profiles";
 import { CirclesRpc } from "@aboutcircles/sdk-rpc";
 import {
+  createFlowMatrix,
   getTokenInfoMapFromPath,
   getWrappedTokensFromPath,
   replaceWrappedTokensWithAvatars,
   shrinkPathValues,
 } from "@aboutcircles/sdk-pathfinder";
+import { encodeFunctionData, encodePacked, concatHex } from 'viem';
 import cacheService from './cacheService';
 
 export const API_ENDPOINT = 'https://rpc.aboutcircles.com/';
@@ -60,6 +62,40 @@ export const parseAddressList = (addressString) => {
     .filter(addr => addr && addr.startsWith('0x'));
 };
 
+const parseJsonArray = (jsonText, fallback = []) => {
+  if (!jsonText || !jsonText.trim()) return fallback;
+  try {
+    const parsed = JSON.parse(jsonText);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const normalizeAddress = (value) => (typeof value === 'string' ? value.trim().toLowerCase() : '');
+
+const dedupeAddresses = (addresses) => Array.from(new Set(addresses.map(normalizeAddress).filter(Boolean)));
+
+const toValidUint = (value) => {
+  try {
+    const parsed = BigInt(value);
+    return parsed >= 0n ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const stringifyBigInts = (value) => {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(stringifyBigInts);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, stringifyBigInts(nested)])
+    );
+  }
+  return value;
+};
+
 export const ethToWei = (crcAmount) => {
   try {
     if (!crcAmount || isNaN(crcAmount)) return '0';
@@ -89,11 +125,44 @@ export const findPath = async (formData, sdkRpc) => {
     const excludedToTokensArray = formData.IsToTokensExcluded
       ? parseAddressList(formData.ExcludedToTokens) : [];
 
+    const simulatedBalances = parseJsonArray(formData.SimulatedBalances)
+      .map((entry) => {
+        const holder = normalizeAddress(entry?.holder);
+        const token = normalizeAddress(entry?.token);
+        const amount = toValidUint(entry?.amount);
+
+        if (!holder || !token || amount === null) return null;
+        return {
+          holder,
+          token,
+          amount,
+          isWrapped: entry?.isWrapped === true,
+          isStatic: entry?.isStatic === true,
+        };
+      })
+      .filter(Boolean);
+
+    const simulatedTrusts = parseJsonArray(formData.SimulatedTrusts)
+      .map((entry) => {
+        const truster = normalizeAddress(entry?.truster);
+        const trustee = normalizeAddress(entry?.trustee);
+
+        if (!truster || !trustee) return null;
+        return { truster, trustee };
+      })
+      .filter(Boolean);
+
+    const simulatedConsentedAvatars = dedupeAddresses(
+      parseAddressList(formData.SimulatedConsentedAvatars)
+    );
+
     const params = {
-      from: formData.From,
-      to: formData.To,
+      from: normalizeAddress(formData.From),
+      to: normalizeAddress(formData.To),
       targetFlow: BigInt(formData.Amount),
       useWrappedBalances: formData.WithWrap,
+      quantizedMode: formData.QuantizedMode === true,
+      debugShowIntermediateSteps: formData.DebugShowIntermediateSteps === true,
     };
 
     if (fromTokensArray.length > 0) params.fromTokens = fromTokensArray;
@@ -106,18 +175,17 @@ export const findPath = async (formData, sdkRpc) => {
       params.maxTransfers = Number(formData.MaxTransfers);
     }
 
+    if (simulatedBalances.length > 0) params.simulatedBalances = simulatedBalances;
+    if (simulatedTrusts.length > 0) params.simulatedTrusts = simulatedTrusts;
+    if (simulatedConsentedAvatars.length > 0) params.simulatedConsentedAvatars = simulatedConsentedAvatars;
+
     console.log('SDK findPath params:', params);
 
     const result = await rpc.pathfinder.findPath(params);
 
-    // SDK returns bigints — convert to strings for backward compat with visualization
-    return {
-      maxFlow: result.maxFlow.toString(),
-      transfers: result.transfers.map(t => ({
-        ...t,
-        value: t.value.toString(),
-      })),
-    };
+    // SDK returns bigints — convert to strings for backward compatibility,
+    // including optional debug/simulation payloads.
+    return stringifyBigInts(result);
   } catch (err) {
     console.error('SDK findPath error:', err);
     throw err;
@@ -446,4 +514,376 @@ export const fetchSinkTrustAvatars = async (sinkAddress, sdkRpc) => {
     console.error('Error fetching sink trust avatars:', error);
     throw error;
   }
+};
+
+const HUB_ABI_MIN = [
+  {
+    type: 'function',
+    name: 'operateFlowMatrix',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_flowVertices', type: 'address[]' },
+      {
+        name: '_flow',
+        type: 'tuple[]',
+        components: [
+          { name: 'streamSinkId', type: 'uint16' },
+          { name: 'amount', type: 'uint192' },
+        ]
+      },
+      {
+        name: '_streams',
+        type: 'tuple[]',
+        components: [
+          { name: 'sourceCoordinate', type: 'uint16' },
+          { name: 'flowEdgeIds', type: 'uint16[]' },
+          { name: 'data', type: 'bytes' },
+        ]
+      },
+      { name: '_packedCoordinates', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'wrap',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_avatar', type: 'address' },
+      { name: '_amount', type: 'uint256' },
+      { name: '_type', type: 'uint8' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'setApprovalForAll',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'operator', type: 'address' },
+      { name: 'approved', type: 'bool' },
+    ],
+    outputs: [],
+  },
+];
+
+const WRAPPER_ABI_MIN = [
+  {
+    type: 'function',
+    name: 'unwrap',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: '_amount', type: 'uint256' }],
+    outputs: [],
+  },
+];
+
+const SAFE_ABI_MIN = [
+  {
+    type: 'function',
+    name: 'execTransaction',
+    stateMutability: 'payable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'data', type: 'bytes' },
+      { name: 'operation', type: 'uint8' },
+      { name: 'safeTxGas', type: 'uint256' },
+      { name: 'baseGas', type: 'uint256' },
+      { name: 'gasPrice', type: 'uint256' },
+      { name: 'gasToken', type: 'address' },
+      { name: 'refundReceiver', type: 'address' },
+      { name: 'signatures', type: 'bytes' },
+    ],
+    outputs: [{ name: 'success', type: 'bool' }],
+  },
+];
+
+const MULTISEND_ABI_MIN = [
+  {
+    type: 'function',
+    name: 'multiSend',
+    stateMutability: 'payable',
+    inputs: [{ name: 'transactions', type: 'bytes' }],
+    outputs: [],
+  },
+];
+
+const isWrapperType = (type) => (type || '').startsWith('CrcV2_ERC20WrapperDeployed');
+
+const getTransferTokenCandidates = (transfer) => {
+  const candidates = [transfer?.tokenOwner, transfer?.token, transfer?.tokenAddress]
+    .map((value) => (typeof value === 'string' ? value.toLowerCase() : ''))
+    .filter(Boolean);
+  return Array.from(new Set(candidates));
+};
+
+const toHex32 = (value) => value.toString(16).padStart(64, '0');
+
+const asHexData = (value) => {
+  if (!value) return '0x';
+  if (typeof value === 'string') return value;
+  if (value instanceof Uint8Array) {
+    return `0x${Array.from(value).map((b) => b.toString(16).padStart(2, '0')).join('')}`;
+  }
+  return '0x';
+};
+
+const encodeMultiSendTransactions = (calls) => {
+  const chunks = calls.map((call) => {
+    const to = call.to.toLowerCase().replace(/^0x/, '').padStart(40, '0');
+    const data = (call.data || '0x').replace(/^0x/, '');
+    const operation = '00';
+    const value = toHex32(0n);
+    const dataLength = toHex32(BigInt(data.length / 2));
+    return `${operation}${to}${value}${dataLength}${data}`;
+  });
+  return `0x${chunks.join('')}`;
+};
+
+const buildPreValidatedSignature = (owner) => {
+  const normalized = owner?.toLowerCase();
+  return concatHex([
+    encodePacked(['address'], [normalized]),
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+    '0x01'
+  ]);
+};
+
+export const buildSafeFlowMatrixSimulationTx = async ({
+  pathData,
+  sender,
+  receiver,
+  signer,
+  hubAddress,
+  multisendAddress = '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
+  rpcUrl = API_ENDPOINT,
+}) => {
+  if (!pathData?.transfers?.length) throw new Error('No transfers available to simulate.');
+  if (!sender || !receiver) throw new Error('Sender and receiver are required for simulation.');
+  if (!signer) throw new Error('Connected signer address is required for simulation.');
+
+  const source = sender.toLowerCase();
+  const sink = receiver.toLowerCase();
+  const normalizedSigner = signer.toLowerCase();
+  const hub = (hubAddress || HUB_ADDRESS).toLowerCase();
+  const logLines = [];
+  const log = (line = '') => {
+    logLines.push(line);
+  };
+
+  log(`Simulation context: sender/safe=${source}, receiver=${sink}, signer=${normalizedSigner}`);
+
+  const pathWithBigInts = {
+    maxFlow: BigInt(pathData.maxFlow),
+    transfers: pathData.transfers.map((transfer) => ({
+      ...transfer,
+      from: transfer.from.toLowerCase(),
+      to: transfer.to.toLowerCase(),
+      tokenOwner: (transfer.tokenOwner || transfer.token || transfer.tokenAddress || '').toLowerCase(),
+      token: (transfer.token || '').toLowerCase(),
+      tokenAddress: (transfer.tokenAddress || '').toLowerCase(),
+      value: BigInt(transfer.value),
+    })),
+  };
+
+  const tokenInfoMap = await getTokenInfoMapFromPath(source, rpcUrl, pathWithBigInts);
+  log(`The path contains ${pathWithBigInts.transfers.length} transfers with a total flow of (demurraged: ${pathWithBigInts.maxFlow}) over ${tokenInfoMap.size} different token owners.`);
+
+  const resolveTokenInfo = (transfer) => {
+    const candidates = getTransferTokenCandidates(transfer);
+    for (const key of candidates) {
+      const info = tokenInfoMap.get(key);
+      if (info) return { info, key };
+    }
+    return { info: undefined, key: undefined };
+  };
+
+  const senderEdges = pathWithBigInts.transfers.filter((transfer) => transfer.from === source);
+  const wrappedSenderEdges = senderEdges
+    .map((transfer) => ({
+      transfer,
+      ...resolveTokenInfo(transfer),
+    }))
+    .filter(({ info }) => isWrapperType(info?.type));
+  log(`The path contains ${wrappedSenderEdges.length} wrapped edges originating from the sender.`);
+
+  if (wrappedSenderEdges.length === 0 && senderEdges.length > 0) {
+    const diagnostics = senderEdges
+      .slice(0, 8)
+      .map((transfer) => {
+        const candidates = getTransferTokenCandidates(transfer);
+        const resolvedType = candidates.map((key) => `${key}:${tokenInfoMap.get(key)?.type || 'unknown'}`).join(', ');
+        return `    - token candidates [${candidates.join(', ')}] => ${resolvedType || 'no candidates'}`;
+      });
+    log('  Sender edge diagnostics (first 8):');
+    diagnostics.forEach((line) => log(line));
+  }
+
+  const staticByWrapper = {};
+  const demurragedByWrapper = {};
+
+  wrappedSenderEdges.forEach(({ transfer, info, key }) => {
+    const wrapperKey = (key || transfer.tokenOwner || '').toLowerCase();
+    if (!wrapperKey) return;
+    if (info?.type === 'CrcV2_ERC20WrapperDeployed_Inflationary') {
+      staticByWrapper[wrapperKey] = (staticByWrapper[wrapperKey] || 0n) + transfer.value;
+    }
+    if (info?.type === 'CrcV2_ERC20WrapperDeployed_Demurraged') {
+      demurragedByWrapper[wrapperKey] = (demurragedByWrapper[wrapperKey] || 0n) + transfer.value;
+    }
+  });
+
+  const staticEntries = Object.entries(staticByWrapper);
+  const demurragedEntries = Object.entries(demurragedByWrapper);
+  log(`  - Of which ${staticEntries.length} use static wrapped tokens:`);
+  staticEntries.forEach(([wrapper, total]) => {
+    log(`    - ${wrapper} (demurraged: ${total})`);
+  });
+  log(`  - Of which ${demurragedEntries.length} use demurraged wrapped tokens:`);
+  demurragedEntries.forEach(([wrapper, total]) => {
+    log(`    - ${wrapper} (demurraged: ${total})`);
+  });
+  log();
+
+  const unwrapCalls = [];
+  const wrapCalls = [];
+  const staticWrapperBalances = {};
+
+  const senderBalances = await fetchAddressTokenBalances(source, false);
+  if (staticEntries.length > 0) {
+    log(`The path uses ${staticEntries.length} different static tokens which must be unwrapped completely before they can be used in a flow matrix transfer.`);
+    log('  Getting all balances of the sender for static wrapped tokens...');
+  }
+  senderBalances.forEach((row) => {
+    const tokenAddress = row?.tokenAddress?.toLowerCase?.();
+    if (!tokenAddress || !staticByWrapper[tokenAddress]) return;
+    const staticUnits = BigInt(row?.staticAttoCircles || row?.attoStaticCircles || row?.attoCircles || '0');
+    staticWrapperBalances[tokenAddress] = staticUnits;
+    log(`    - ${tokenAddress} (static: ${staticUnits})`);
+    if (staticUnits > 0n) {
+      log(`      > Unwrapping full amount of static wrapped token: ${tokenAddress} (static: ${staticUnits})`);
+      unwrapCalls.push({
+        to: tokenAddress,
+        data: encodeFunctionData({ abi: WRAPPER_ABI_MIN, functionName: 'unwrap', args: [staticUnits] }),
+      });
+    }
+  });
+
+  Object.entries(demurragedByWrapper).forEach(([wrapper, amount]) => {
+    if (amount <= 0n) return;
+    log(`  > Unwrapping precise amount of demurraged wrapped token: ${wrapper} (demurraged: ${amount})`);
+    unwrapCalls.push({
+      to: wrapper,
+      data: encodeFunctionData({ abi: WRAPPER_ABI_MIN, functionName: 'unwrap', args: [amount] }),
+    });
+  });
+  log();
+  log('Replacing wrapped token owners in the path with their real token owners...');
+
+  const staticSpent = {};
+  const rewrittenTransfers = pathWithBigInts.transfers.map((transfer) => {
+    const { info, key } = resolveTokenInfo(transfer);
+    if (!info || !isWrapperType(info.type)) return transfer;
+    log(` - Replacing wrapped token owner in transfer (from: ${transfer.from}, to: ${transfer.to}, tokenOwner: ${transfer.tokenOwner}) with real token owner: ${info.tokenOwner}`);
+    if (info.type === 'CrcV2_ERC20WrapperDeployed_Inflationary') {
+      const wrapperKey = (key || transfer.tokenOwner || '').toLowerCase();
+      staticSpent[wrapperKey] = (staticSpent[wrapperKey] || 0n) + transfer.value;
+    }
+    return {
+      ...transfer,
+      tokenOwner: (info.tokenOwner || transfer.tokenOwner).toLowerCase(),
+    };
+  });
+
+  Object.entries(staticWrapperBalances).forEach(([wrapperToken, unwrappedTotal]) => {
+    const spent = staticSpent[wrapperToken] || 0n;
+    const remaining = unwrappedTotal > spent ? unwrappedTotal - spent : 0n;
+    log(`  - ${wrapperToken}: spent (demurraged: ${spent}), remaining to re-wrap (demurraged: ${remaining})`);
+    if (remaining <= 0n) return;
+
+    const realTokenOwner = tokenInfoMap.get(wrapperToken)?.tokenOwner;
+    if (!realTokenOwner) return;
+
+    wrapCalls.push({
+      to: hub,
+      data: encodeFunctionData({
+        abi: HUB_ABI_MIN,
+        functionName: 'wrap',
+        args: [realTokenOwner.toLowerCase(), remaining, 1],
+      }),
+    });
+  });
+
+  const flowMatrix = createFlowMatrix(source, sink, BigInt(pathWithBigInts.maxFlow), rewrittenTransfers);
+  log();
+  log(`Flow matrix created with ${flowMatrix.flowVertices.length} vertices and ${flowMatrix.flowEdges.length} edges.`);
+
+  const operateFlowMatrixCall = {
+    to: hub,
+    data: encodeFunctionData({
+      abi: HUB_ABI_MIN,
+      functionName: 'operateFlowMatrix',
+      args: [
+        flowMatrix.flowVertices,
+        flowMatrix.flowEdges.map((edge) => ({ streamSinkId: edge.streamSinkId, amount: BigInt(edge.amount) })),
+        flowMatrix.streams.map((stream) => ({
+          sourceCoordinate: stream.sourceCoordinate,
+          flowEdgeIds: stream.flowEdgeIds,
+          data: asHexData(stream.data),
+        })),
+        flowMatrix.packedCoordinates,
+      ],
+    }),
+  };
+
+  const selfApprovalCall = {
+    to: hub,
+    data: encodeFunctionData({
+      abi: HUB_ABI_MIN,
+      functionName: 'setApprovalForAll',
+      args: [hub, true],
+    }),
+  };
+
+  const calls = [selfApprovalCall, ...unwrapCalls, operateFlowMatrixCall, ...wrapCalls];
+  log(`Planned sub-calls: ${calls.length} (self-approval: 1, unwrap: ${unwrapCalls.length}, operateFlowMatrix: 1, re-wrap: ${wrapCalls.length}).`);
+  log('Order: self-approval → unwrap(s) → operateFlowMatrix → re-wrap(s)');
+  const packedCalls = encodeMultiSendTransactions(calls);
+  const multiSendCallData = encodeFunctionData({
+    abi: MULTISEND_ABI_MIN,
+    functionName: 'multiSend',
+    args: [packedCalls],
+  });
+
+  const safeCalldata = encodeFunctionData({
+    abi: SAFE_ABI_MIN,
+    functionName: 'execTransaction',
+    args: [
+      multisendAddress,
+      0n,
+      multiSendCallData,
+      1,
+      0n,
+      0n,
+      0n,
+      '0x0000000000000000000000000000000000000000',
+      '0x0000000000000000000000000000000000000000',
+      buildPreValidatedSignature(signer),
+    ],
+  });
+
+  return {
+    safeAddress: source,
+    gasFrom: normalizedSigner,
+    safeCalldata,
+    flowMatrix,
+    summary: {
+      wrappedEdgesFromSender: wrappedSenderEdges.length,
+      unwrapCalls: unwrapCalls.length,
+      wrapCalls: wrapCalls.length,
+      calls: calls.length,
+      rewrittenTransfers: rewrittenTransfers.length,
+    },
+    simulationLog: logLines.join('\n'),
+  };
 };

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -6,9 +6,8 @@ import {
   getTokenInfoMapFromPath,
   getWrappedTokensFromPath,
   replaceWrappedTokensWithAvatars,
-  shrinkPathValues,
 } from "@aboutcircles/sdk-pathfinder";
-import { encodeFunctionData, encodePacked, concatHex } from 'viem';
+import { encodeFunctionData, concatHex } from 'viem';
 import cacheService from './cacheService';
 
 export const API_ENDPOINT = 'https://rpc.aboutcircles.com/';
@@ -608,7 +607,24 @@ const MULTISEND_ABI_MIN = [
   },
 ];
 
-const isWrapperType = (type) => (type || '').startsWith('CrcV2_ERC20WrapperDeployed');
+const getTokenType = (info) => (info?.tokenType || info?.type || '');
+
+const isWrapperInfo = (info) => {
+  if (!info) return false;
+  const tokenType = getTokenType(info);
+  return !!(info.isWrapped || tokenType.startsWith('CrcV2_ERC20WrapperDeployed') || tokenType.includes('ERC20Wrapper'));
+};
+
+const isStaticWrapperInfo = (info) => {
+  if (!isWrapperInfo(info)) return false;
+  const tokenType = getTokenType(info);
+  return info.isInflationary === true || tokenType.includes('Inflationary');
+};
+
+const isDemurragedWrapperInfo = (info) => {
+  if (!isWrapperInfo(info)) return false;
+  return !isStaticWrapperInfo(info);
+};
 
 const getTransferTokenCandidates = (transfer) => {
   const candidates = [transfer?.tokenOwner, transfer?.token, transfer?.tokenAddress]
@@ -642,11 +658,34 @@ const encodeMultiSendTransactions = (calls) => {
 
 const buildPreValidatedSignature = (owner) => {
   const normalized = owner?.toLowerCase();
+  const ownerWord = `0x${(normalized || '').replace(/^0x/, '').padStart(64, '0')}`;
   return concatHex([
-    encodePacked(['address'], [normalized]),
+    ownerWord,
     '0x0000000000000000000000000000000000000000000000000000000000000000',
     '0x01'
   ]);
+};
+
+const hexByteLength = (hex) => {
+  if (!hex || typeof hex !== 'string') return 0;
+  const normalized = hex.startsWith('0x') ? hex.slice(2) : hex;
+  return Math.floor(normalized.length / 2);
+};
+
+const getCallLabel = (call, hubAddress) => {
+  const to = (call?.to || '').toLowerCase();
+  const data = (call?.data || '').toLowerCase();
+  const selector = data.slice(0, 10);
+
+  if (to === (hubAddress || '').toLowerCase()) {
+    if (selector === '0xa9059cbb') return 'erc20.transfer';
+    if (selector === '0xe985e9c5') return 'setApprovalForAll';
+    if (selector === '0x3748f953') return 'operateFlowMatrix';
+    if (selector === '0xea598cb0') return 'wrap';
+  }
+
+  if (selector === '0xde0e9a3e') return 'unwrap';
+  return 'unknown';
 };
 
 export const buildSafeFlowMatrixSimulationTx = async ({
@@ -704,7 +743,7 @@ export const buildSafeFlowMatrixSimulationTx = async ({
       transfer,
       ...resolveTokenInfo(transfer),
     }))
-    .filter(({ info }) => isWrapperType(info?.type));
+    .filter(({ info }) => isWrapperInfo(info));
   log(`The path contains ${wrappedSenderEdges.length} wrapped edges originating from the sender.`);
 
   if (wrappedSenderEdges.length === 0 && senderEdges.length > 0) {
@@ -712,7 +751,9 @@ export const buildSafeFlowMatrixSimulationTx = async ({
       .slice(0, 8)
       .map((transfer) => {
         const candidates = getTransferTokenCandidates(transfer);
-        const resolvedType = candidates.map((key) => `${key}:${tokenInfoMap.get(key)?.type || 'unknown'}`).join(', ');
+        const resolvedType = candidates
+          .map((key) => `${key}:${getTokenType(tokenInfoMap.get(key)) || 'unknown'}`)
+          .join(', ');
         return `    - token candidates [${candidates.join(', ')}] => ${resolvedType || 'no candidates'}`;
       });
     log('  Sender edge diagnostics (first 8):');
@@ -725,10 +766,10 @@ export const buildSafeFlowMatrixSimulationTx = async ({
   wrappedSenderEdges.forEach(({ transfer, info, key }) => {
     const wrapperKey = (key || transfer.tokenOwner || '').toLowerCase();
     if (!wrapperKey) return;
-    if (info?.type === 'CrcV2_ERC20WrapperDeployed_Inflationary') {
+    if (isStaticWrapperInfo(info)) {
       staticByWrapper[wrapperKey] = (staticByWrapper[wrapperKey] || 0n) + transfer.value;
     }
-    if (info?.type === 'CrcV2_ERC20WrapperDeployed_Demurraged') {
+    if (isDemurragedWrapperInfo(info)) {
       demurragedByWrapper[wrapperKey] = (demurragedByWrapper[wrapperKey] || 0n) + transfer.value;
     }
   });
@@ -748,6 +789,32 @@ export const buildSafeFlowMatrixSimulationTx = async ({
   const unwrapCalls = [];
   const wrapCalls = [];
   const staticWrapperBalances = {};
+  const staticWrapperDiagnostics = {};
+  const demurragedWrapperDiagnostics = {};
+
+  Object.entries(staticByWrapper).forEach(([wrapper, amount]) => {
+    staticWrapperDiagnostics[wrapper] = {
+      wrapper,
+      pathDemurraged: amount,
+      staticBalanceUnwrapped: 0n,
+      demurragedBalanceUnwrapped: 0n,
+      demurragedSpent: 0n,
+      demurragedRemainingToWrap: 0n,
+      unwrapCallPlanned: false,
+      wrapCallPlanned: false,
+      tokenOwner: tokenInfoMap.get(wrapper)?.tokenOwner?.toLowerCase?.() || null,
+    };
+  });
+
+  Object.entries(demurragedByWrapper).forEach(([wrapper, amount]) => {
+    demurragedWrapperDiagnostics[wrapper] = {
+      wrapper,
+      pathDemurraged: amount,
+      demurragedUnwrapAmount: amount,
+      unwrapCallPlanned: amount > 0n,
+      tokenOwner: tokenInfoMap.get(wrapper)?.tokenOwner?.toLowerCase?.() || null,
+    };
+  });
 
   const senderBalances = await fetchAddressTokenBalances(source, false);
   if (staticEntries.length > 0) {
@@ -757,15 +824,26 @@ export const buildSafeFlowMatrixSimulationTx = async ({
   senderBalances.forEach((row) => {
     const tokenAddress = row?.tokenAddress?.toLowerCase?.();
     if (!tokenAddress || !staticByWrapper[tokenAddress]) return;
-    const staticUnits = BigInt(row?.staticAttoCircles || row?.attoStaticCircles || row?.attoCircles || '0');
-    staticWrapperBalances[tokenAddress] = staticUnits;
-    log(`    - ${tokenAddress} (static: ${staticUnits})`);
+    const staticUnits = BigInt(row?.staticAttoCircles || row?.attoStaticCircles || '0');
+    const demurragedUnits = BigInt(row?.attoCircles || '0');
+    staticWrapperBalances[tokenAddress] = {
+      static: staticUnits,
+      demurraged: demurragedUnits,
+    };
+    if (staticWrapperDiagnostics[tokenAddress]) {
+      staticWrapperDiagnostics[tokenAddress].staticBalanceUnwrapped = staticUnits;
+      staticWrapperDiagnostics[tokenAddress].demurragedBalanceUnwrapped = demurragedUnits;
+    }
+    log(`    - ${tokenAddress} (static: ${staticUnits}, demurraged: ${demurragedUnits})`);
     if (staticUnits > 0n) {
       log(`      > Unwrapping full amount of static wrapped token: ${tokenAddress} (static: ${staticUnits})`);
       unwrapCalls.push({
         to: tokenAddress,
         data: encodeFunctionData({ abi: WRAPPER_ABI_MIN, functionName: 'unwrap', args: [staticUnits] }),
       });
+      if (staticWrapperDiagnostics[tokenAddress]) {
+        staticWrapperDiagnostics[tokenAddress].unwrapCallPlanned = true;
+      }
     }
   });
 
@@ -776,6 +854,9 @@ export const buildSafeFlowMatrixSimulationTx = async ({
       to: wrapper,
       data: encodeFunctionData({ abi: WRAPPER_ABI_MIN, functionName: 'unwrap', args: [amount] }),
     });
+    if (demurragedWrapperDiagnostics[wrapper]) {
+      demurragedWrapperDiagnostics[wrapper].unwrapCallPlanned = true;
+    }
   });
   log();
   log('Replacing wrapped token owners in the path with their real token owners...');
@@ -783,9 +864,9 @@ export const buildSafeFlowMatrixSimulationTx = async ({
   const staticSpent = {};
   const rewrittenTransfers = pathWithBigInts.transfers.map((transfer) => {
     const { info, key } = resolveTokenInfo(transfer);
-    if (!info || !isWrapperType(info.type)) return transfer;
+    if (!isWrapperInfo(info)) return transfer;
     log(` - Replacing wrapped token owner in transfer (from: ${transfer.from}, to: ${transfer.to}, tokenOwner: ${transfer.tokenOwner}) with real token owner: ${info.tokenOwner}`);
-    if (info.type === 'CrcV2_ERC20WrapperDeployed_Inflationary') {
+    if (isStaticWrapperInfo(info)) {
       const wrapperKey = (key || transfer.tokenOwner || '').toLowerCase();
       staticSpent[wrapperKey] = (staticSpent[wrapperKey] || 0n) + transfer.value;
     }
@@ -797,7 +878,12 @@ export const buildSafeFlowMatrixSimulationTx = async ({
 
   Object.entries(staticWrapperBalances).forEach(([wrapperToken, unwrappedTotal]) => {
     const spent = staticSpent[wrapperToken] || 0n;
-    const remaining = unwrappedTotal > spent ? unwrappedTotal - spent : 0n;
+    const unwrappedTotalDemurraged = unwrappedTotal.demurraged || 0n;
+    const remaining = unwrappedTotalDemurraged > spent ? unwrappedTotalDemurraged - spent : 0n;
+    if (staticWrapperDiagnostics[wrapperToken]) {
+      staticWrapperDiagnostics[wrapperToken].demurragedSpent = spent;
+      staticWrapperDiagnostics[wrapperToken].demurragedRemainingToWrap = remaining;
+    }
     log(`  - ${wrapperToken}: spent (demurraged: ${spent}), remaining to re-wrap (demurraged: ${remaining})`);
     if (remaining <= 0n) return;
 
@@ -812,6 +898,10 @@ export const buildSafeFlowMatrixSimulationTx = async ({
         args: [realTokenOwner.toLowerCase(), remaining, 1],
       }),
     });
+    if (staticWrapperDiagnostics[wrapperToken]) {
+      staticWrapperDiagnostics[wrapperToken].wrapCallPlanned = true;
+      staticWrapperDiagnostics[wrapperToken].tokenOwner = realTokenOwner.toLowerCase();
+    }
   });
 
   const flowMatrix = createFlowMatrix(source, sink, BigInt(pathWithBigInts.maxFlow), rewrittenTransfers);
@@ -841,7 +931,7 @@ export const buildSafeFlowMatrixSimulationTx = async ({
     data: encodeFunctionData({
       abi: HUB_ABI_MIN,
       functionName: 'setApprovalForAll',
-      args: [hub, true],
+      args: [source, true],
     }),
   };
 
@@ -854,6 +944,12 @@ export const buildSafeFlowMatrixSimulationTx = async ({
     functionName: 'multiSend',
     args: [packedCalls],
   });
+
+  const signature = buildPreValidatedSignature(signer);
+  const signatureBytes = hexByteLength(signature);
+  if (signatureBytes !== 65) {
+    throw new Error(`Invalid prevalidated Safe signature length: expected 65 bytes, got ${signatureBytes}.`);
+  }
 
   const safeCalldata = encodeFunctionData({
     abi: SAFE_ABI_MIN,
@@ -868,9 +964,32 @@ export const buildSafeFlowMatrixSimulationTx = async ({
       0n,
       '0x0000000000000000000000000000000000000000',
       '0x0000000000000000000000000000000000000000',
-      buildPreValidatedSignature(signer),
+      signature,
     ],
   });
+
+  const callTimeline = calls.map((call, index) => ({
+    index,
+    to: call.to,
+    label: getCallLabel(call, hub),
+    selector: (call.data || '').slice(0, 10),
+    dataLengthBytes: Math.max(0, ((call.data || '0x').length - 2) / 2),
+  }));
+
+  const staticWrapperRows = Object.values(staticWrapperDiagnostics)
+    .sort((a, b) => a.wrapper.localeCompare(b.wrapper));
+  const demurragedWrapperRows = Object.values(demurragedWrapperDiagnostics)
+    .sort((a, b) => a.wrapper.localeCompare(b.wrapper));
+
+  const wrappedEdgesByType = {
+    static: wrappedSenderEdges.filter(({ info }) => isStaticWrapperInfo(info)).length,
+    demurraged: wrappedSenderEdges.filter(({ info }) => isDemurragedWrapperInfo(info)).length,
+  };
+
+  const unwrapByType = {
+    static: staticEntries.length,
+    demurraged: demurragedEntries.length,
+  };
 
   return {
     safeAddress: source,
@@ -879,10 +998,19 @@ export const buildSafeFlowMatrixSimulationTx = async ({
     flowMatrix,
     summary: {
       wrappedEdgesFromSender: wrappedSenderEdges.length,
+      wrappedEdgesByType,
       unwrapCalls: unwrapCalls.length,
+      unwrapByType,
       wrapCalls: wrapCalls.length,
       calls: calls.length,
+      signatureBytes,
       rewrittenTransfers: rewrittenTransfers.length,
+    },
+    diagnostics: {
+      staticWrappers: staticWrapperRows,
+      demurragedWrappers: demurragedWrapperRows,
+      callTimeline,
+      callOrderDescription: 'self-approval → unwrap(s) → operateFlowMatrix → re-wrap(s)',
     },
     simulationLog: logLines.join('\n'),
   };

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -114,15 +114,13 @@ export const findPath = async (formData, sdkRpc) => {
   const endpoint = formData.UseStaging ? STAGING_ENDPOINT : API_ENDPOINT;
   const rpc = formData.UseStaging ? new CirclesRpc(STAGING_ENDPOINT) : sdkRpc;
   try {
-    // Only send the active mode's token fields — include OR exclude, never both
+    // Include and exclude can coexist when quick-filter sends both
     const fromTokensArray = formData.IsFromTokensExcluded
       ? [] : parseAddressList(formData.FromTokens);
-    const excludedFromTokensArray = formData.IsFromTokensExcluded
-      ? parseAddressList(formData.ExcludedFromTokens) : [];
+    const excludedFromTokensArray = parseAddressList(formData.ExcludedFromTokens);
     const toTokensArray = formData.IsToTokensExcluded
       ? [] : parseAddressList(formData.ToTokens);
-    const excludedToTokensArray = formData.IsToTokensExcluded
-      ? parseAddressList(formData.ExcludedToTokens) : [];
+    const excludedToTokensArray = parseAddressList(formData.ExcludedToTokens);
 
     const simulatedBalances = parseJsonArray(formData.SimulatedBalances)
       .map((entry) => {
@@ -704,7 +702,8 @@ export const buildSafeFlowMatrixSimulationTx = async ({
   const source = sender.toLowerCase();
   const sink = receiver.toLowerCase();
   const normalizedSigner = signer.toLowerCase();
-  const hub = (hubAddress || HUB_ADDRESS).toLowerCase();
+  if (!hubAddress) throw new Error('Hub contract address is required for simulation.');
+  const hub = hubAddress.toLowerCase();
   const logLines = [];
   const log = (line = '') => {
     logLines.push(line);
@@ -846,6 +845,12 @@ export const buildSafeFlowMatrixSimulationTx = async ({
       }
     }
   });
+
+  for (const [wrapper] of staticEntries) {
+    if (!staticWrapperBalances[wrapper]) {
+      log(`  WARNING: No balance found for static wrapper ${wrapper} — unwrap cannot be planned. Simulation will likely revert.`);
+    }
+  }
 
   Object.entries(demurragedByWrapper).forEach(([wrapper, amount]) => {
     if (amount <= 0n) return;


### PR DESCRIPTION
## Summary
- Cherry-picks simulation commits from `fix/layout` branch (by jaensen)
- Safe-compatible `operateFlowMatrix` simulation via `eth_estimateGas` dry-run
- Simulation tab in bottom panel with gas estimate, wrapper diagnostics, sub-call timeline
- Simulation editor modal for hypothetical balances/trusts
- UX fixes: unified "Auto-search" toggle, "Clear all" for token lists, auto-run on page load, InfoTips on source balances/sink trust tabs
- Fix: quick filter now properly excludes wrapped tokens via `excludeFromTokens`
- Fix: simulation editor modal styling (solid background, proper Tailwind classes)
- Disabled SDK-unsupported fields (QuantizedMode, DebugShowIntermediateSteps, SimulatedConsentedAvatars) pending `sdk-rpc` normalization support
- MaxTransfers validation (integer 1-500)

## Test plan
- [x] Path finding + graph/sankey visualization works
- [x] All 4 bottom tabs render correctly (Routes, Flow Matrix Parameters, Simulation, Path Stats)
- [x] Wallet connection via Rabby in Brave
- [x] Simulation runs end-to-end (gas estimate: 671,236 for test path)
- [x] Wrapper diagnostics table + sub-call timeline displayed
- [x] Simulation editor modal: add/edit/remove rows, Apply persists data
- [x] Auto-search toggle shared between source balances and sink trust
- [x] Quick filter properly excludes unchecked tokens from pathfinder
- [x] Auto-run findPath on page load with persisted form values
- [x] Clear all button works on From/To token lists
- [x] Build passes cleanly