### PR TITLE
feat: test environment mode for historical pathfinding

### DIFF
--- a/src/components/CollapsibleLeftPanel.jsx
+++ b/src/components/CollapsibleLeftPanel.jsx
@@ -16,8 +16,12 @@ const CollapsibleLeftPanel = ({
   handleTokensChange,
   handleWithWrapToggle,
   handleStagingToggle,
+  handleTestEnvToggle,
+  handleTestEnvUrlChange,
+  handleTestEnvBlockNumberChange,
   handleQuantizedModeToggle,
   handleDebugIntermediateToggle,
+  testEnvSession,
   handleFromTokensExclusionToggle,
   handleToTokensExclusionToggle,
   onFindPath,
@@ -96,8 +100,12 @@ const CollapsibleLeftPanel = ({
                 handleTokensChange={handleTokensChange}
                 handleWithWrapToggle={handleWithWrapToggle}
                 handleStagingToggle={handleStagingToggle}
+                handleTestEnvToggle={handleTestEnvToggle}
+                handleTestEnvUrlChange={handleTestEnvUrlChange}
+                handleTestEnvBlockNumberChange={handleTestEnvBlockNumberChange}
                 handleQuantizedModeToggle={handleQuantizedModeToggle}
                 handleDebugIntermediateToggle={handleDebugIntermediateToggle}
+                testEnvSession={testEnvSession}
                 handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}
                 handleToTokensExclusionToggle={handleToTokensExclusionToggle}
                 onFindPath={onFindPath}

--- a/src/components/CollapsibleLeftPanel.jsx
+++ b/src/components/CollapsibleLeftPanel.jsx
@@ -22,6 +22,7 @@ const CollapsibleLeftPanel = ({
   handleQuantizedModeToggle,
   handleDebugIntermediateToggle,
   testEnvSession,
+  onDestroySession,
   handleFromTokensExclusionToggle,
   handleToTokensExclusionToggle,
   onFindPath,
@@ -106,6 +107,7 @@ const CollapsibleLeftPanel = ({
                 handleQuantizedModeToggle={handleQuantizedModeToggle}
                 handleDebugIntermediateToggle={handleDebugIntermediateToggle}
                 testEnvSession={testEnvSession}
+                onDestroySession={onDestroySession}
                 handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}
                 handleToTokensExclusionToggle={handleToTokensExclusionToggle}
                 onFindPath={onFindPath}

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -6,6 +6,7 @@ import { usePerformance } from '@/contexts/PerformanceContext';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { decomposeFlow, transfersFromRoutes } from '@/utils/flowDecomposition';
 import { parseAddressList } from '@/services/circlesApi';
+import { getOrCreateSession } from '@/services/testEnvService';
 import Header from '@/components/ui/header';
 import CollapsibleLeftPanel from '@/components/CollapsibleLeftPanel';
 import CytoscapeVisualization from '@/components/CytoscapeVisualization';
@@ -49,6 +50,9 @@ const FlowVisualization = () => {
     handleTokensChange, 
     handleWithWrapToggle,
     handleStagingToggle,
+    handleTestEnvToggle,
+    handleTestEnvUrlChange,
+    handleTestEnvBlockNumberChange,
     handleQuantizedModeToggle,
     handleDebugIntermediateToggle,
     handleFromTokensExclusionToggle,
@@ -58,6 +62,7 @@ const FlowVisualization = () => {
     validateFormData,
   } = useFormData();
   const [formWarnings, setFormWarnings] = useState([]);
+  const [testEnvSession, setTestEnvSession] = useState(null);
   
   const {
     pathData,
@@ -416,6 +421,28 @@ const FlowVisualization = () => {
     if (!validation.isValid) {
       return;
     }
+
+    // If test-env mode, create/reuse session and attach to formData
+    if (baseData.UseTestEnv) {
+      if (!baseData.TestEnvBlockNumber) {
+        setFormWarnings(['Enter a block number for test environment mode']);
+        return;
+      }
+      try {
+        const session = await getOrCreateSession(
+          baseData.TestEnvUrl,
+          Number(baseData.TestEnvBlockNumber)
+        );
+        setTestEnvSession(session);
+        await executeFindPath({ ...baseData, testEnvSession: session });
+      } catch (err) {
+        setFormWarnings([`Test-env session error: ${err.message}`]);
+        setTestEnvSession(null);
+      }
+      return;
+    }
+
+    setTestEnvSession(null);
     await executeFindPath(baseData);
   }, [formData, executeFindPath, validateFormData]);
 
@@ -836,6 +863,10 @@ const FlowVisualization = () => {
             handleTokensChange={handleTokensChange}
             handleWithWrapToggle={handleWithWrapToggle}
             handleStagingToggle={handleStagingToggle}
+            handleTestEnvToggle={handleTestEnvToggle}
+            handleTestEnvUrlChange={handleTestEnvUrlChange}
+            handleTestEnvBlockNumberChange={handleTestEnvBlockNumberChange}
+            testEnvSession={testEnvSession}
             handleQuantizedModeToggle={handleQuantizedModeToggle}
             handleDebugIntermediateToggle={handleDebugIntermediateToggle}
             handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -6,7 +6,7 @@ import { usePerformance } from '@/contexts/PerformanceContext';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { decomposeFlow, transfersFromRoutes } from '@/utils/flowDecomposition';
 import { parseAddressList } from '@/services/circlesApi';
-import { getOrCreateSession } from '@/services/testEnvService';
+import { getOrCreateSession, destroySession } from '@/services/testEnvService';
 import Header from '@/components/ui/header';
 import CollapsibleLeftPanel from '@/components/CollapsibleLeftPanel';
 import CytoscapeVisualization from '@/components/CytoscapeVisualization';
@@ -63,7 +63,12 @@ const FlowVisualization = () => {
   } = useFormData();
   const [formWarnings, setFormWarnings] = useState([]);
   const [testEnvSession, setTestEnvSession] = useState(null);
-  
+
+  const handleDestroySession = useCallback(async () => {
+    await destroySession();
+    setTestEnvSession(null);
+  }, []);
+
   const {
     pathData,
     rawPathData,
@@ -358,7 +363,11 @@ const FlowVisualization = () => {
         setTestEnvSession(session);
         await loadPathData({ ...requestData, testEnvSession: session });
       } catch (err) {
-        setFormWarnings([`Test-env session error: ${err.message}`]);
+        const isMaxSessions = err.message.includes('Maximum concurrent sessions');
+        const hint = isMaxSessions
+          ? ' — close unused sessions or wait for them to expire (30 min TTL).'
+          : '';
+        setFormWarnings([`Test-env session error: ${err.message}${hint}`]);
         setTestEnvSession(null);
       }
       return;
@@ -869,6 +878,7 @@ const FlowVisualization = () => {
             handleTestEnvUrlChange={handleTestEnvUrlChange}
             handleTestEnvBlockNumberChange={handleTestEnvBlockNumberChange}
             testEnvSession={testEnvSession}
+            onDestroySession={handleDestroySession}
             handleQuantizedModeToggle={handleQuantizedModeToggle}
             handleDebugIntermediateToggle={handleDebugIntermediateToggle}
             handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -342,8 +342,31 @@ const FlowVisualization = () => {
     setSelectedTransactionId(null);
     clearHighlights();
 
+    // If test-env mode, ensure we have a valid session attached
+    if (requestData.UseTestEnv) {
+      if (!requestData.TestEnvBlockNumber) {
+        setFormWarnings(['Enter a block number for test environment mode']);
+        return;
+      }
+      const parsedBlock = Number(requestData.TestEnvBlockNumber);
+      if (!Number.isInteger(parsedBlock) || parsedBlock < 0) {
+        setFormWarnings(['Block number must be a non-negative integer']);
+        return;
+      }
+      try {
+        const session = await getOrCreateSession(requestData.TestEnvUrl, parsedBlock);
+        setTestEnvSession(session);
+        await loadPathData({ ...requestData, testEnvSession: session });
+      } catch (err) {
+        setFormWarnings([`Test-env session error: ${err.message}`]);
+        setTestEnvSession(null);
+      }
+      return;
+    }
+
+    setTestEnvSession(null);
     await loadPathData(requestData);
-  }, [loadPathData, clearHighlights]);
+  }, [loadPathData, clearHighlights, setFormWarnings, setTestEnvSession]);
 
   const selectQuickTokensByPredicate = useCallback(async (predicate) => {
     const allTokens = Array.from(new Set(
@@ -422,27 +445,6 @@ const FlowVisualization = () => {
       return;
     }
 
-    // If test-env mode, create/reuse session and attach to formData
-    if (baseData.UseTestEnv) {
-      if (!baseData.TestEnvBlockNumber) {
-        setFormWarnings(['Enter a block number for test environment mode']);
-        return;
-      }
-      try {
-        const session = await getOrCreateSession(
-          baseData.TestEnvUrl,
-          Number(baseData.TestEnvBlockNumber)
-        );
-        setTestEnvSession(session);
-        await executeFindPath({ ...baseData, testEnvSession: session });
-      } catch (err) {
-        setFormWarnings([`Test-env session error: ${err.message}`]);
-        setTestEnvSession(null);
-      }
-      return;
-    }
-
-    setTestEnvSession(null);
     await executeFindPath(baseData);
   }, [formData, executeFindPath, validateFormData]);
 

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -58,8 +58,12 @@ const PathFinderForm = ({
   handleTokensChange,
   handleWithWrapToggle,
   handleStagingToggle,
+  handleTestEnvToggle,
+  handleTestEnvUrlChange,
+  handleTestEnvBlockNumberChange,
   handleQuantizedModeToggle,
   handleDebugIntermediateToggle,
+  testEnvSession,
   handleFromTokensExclusionToggle,
   handleToTokensExclusionToggle,
   onFindPath,
@@ -358,6 +362,51 @@ const PathFinderForm = ({
           />
           <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: staging.circlesubi.network\n\nCurrently using: ${formData.UseStaging ? 'staging.circlesubi.network' : 'rpc.aboutcircles.com'}`} />
         </div>
+        <div className="flex items-center">
+          <ToggleSwitch
+            isEnabled={formData.UseTestEnv}
+            onToggle={handleTestEnvToggle}
+            label="Test Environment"
+          />
+          <InfoTip text="Run pathfinder against historical blockchain state at a specific block number. Creates a test-env session that filters all data to that block." />
+        </div>
+        {formData.UseTestEnv && (
+          <div className="ml-4 space-y-2 border-l-2 border-blue-500/30 pl-3">
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-400">Test-Env URL</label>
+              <Input
+                type="text"
+                value={formData.TestEnvUrl}
+                onChange={handleTestEnvUrlChange}
+                className="text-xs"
+                placeholder="https://staging.circlesubi.network/test-env"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-400">Block Number</label>
+              <Input
+                type="text"
+                value={formData.TestEnvBlockNumber}
+                onChange={handleTestEnvBlockNumberChange}
+                className="text-xs"
+                placeholder="e.g. 43193632"
+              />
+            </div>
+            {testEnvSession && (
+              <div className="text-xs text-green-400 bg-green-900/20 rounded p-2">
+                Session active at block {testEnvSession.blockNumber}
+                {testEnvSession.expiresAt && (
+                  <span className="text-gray-500 ml-1">
+                    (expires {new Date(testEnvSession.expiresAt).toLocaleTimeString()})
+                  </span>
+                )}
+              </div>
+            )}
+            {formData.UseTestEnv && !formData.TestEnvBlockNumber && (
+              <div className="text-xs text-yellow-400">Enter a block number to query historical state</div>
+            )}
+          </div>
+        )}
         <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
           <ToggleSwitch
             isEnabled={formData.QuantizedMode}
@@ -630,7 +679,11 @@ PathFinderForm.propTypes = {
   handleTokensChange: PropTypes.func.isRequired,
   handleWithWrapToggle: PropTypes.func.isRequired,
   handleStagingToggle: PropTypes.func.isRequired,
+  handleTestEnvToggle: PropTypes.func.isRequired,
+  handleTestEnvUrlChange: PropTypes.func.isRequired,
+  handleTestEnvBlockNumberChange: PropTypes.func.isRequired,
   handleQuantizedModeToggle: PropTypes.func.isRequired,
+  testEnvSession: PropTypes.object,
   handleDebugIntermediateToggle: PropTypes.func.isRequired,
   handleFromTokensExclusionToggle: PropTypes.func.isRequired,
   handleToTokensExclusionToggle: PropTypes.func.isRequired,

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -64,6 +64,7 @@ const PathFinderForm = ({
   handleQuantizedModeToggle,
   handleDebugIntermediateToggle,
   testEnvSession,
+  onDestroySession,
   handleFromTokensExclusionToggle,
   handleToTokensExclusionToggle,
   onFindPath,
@@ -362,14 +363,16 @@ const PathFinderForm = ({
           />
           <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: staging.circlesubi.network\n\nCurrently using: ${formData.UseStaging ? 'staging.circlesubi.network' : 'rpc.aboutcircles.com'}`} />
         </div>
-        <div className="flex items-center">
-          <ToggleSwitch
-            isEnabled={formData.UseTestEnv}
-            onToggle={handleTestEnvToggle}
-            label="Test Environment"
-          />
-          <InfoTip text="Run pathfinder against historical blockchain state at a specific block number. Creates a test-env session that filters all data to that block." />
-        </div>
+        {formData.UseStaging && (
+          <div className="flex items-center">
+            <ToggleSwitch
+              isEnabled={formData.UseTestEnv}
+              onToggle={handleTestEnvToggle}
+              label="Test Environment"
+            />
+            <InfoTip text="Run pathfinder against historical blockchain state at a specific block number. Creates a test-env session (30 min TTL, max 10 concurrent) that filters all data to that block." />
+          </div>
+        )}
         {formData.UseTestEnv && (
           <div className="ml-4 space-y-2 border-l-2 border-blue-500/30 pl-3">
             <div>
@@ -393,14 +396,27 @@ const PathFinderForm = ({
               />
             </div>
             {testEnvSession && (
-              <div className="text-xs text-green-400 bg-green-900/20 rounded p-2">
-                Session active at block {testEnvSession.blockNumber}
-                {testEnvSession.expiresAt && (
-                  <span className="text-gray-500 ml-1">
-                    (expires {new Date(testEnvSession.expiresAt).toLocaleTimeString()})
-                  </span>
-                )}
+              <div className="text-xs text-gray-300 bg-gray-800/60 border border-gray-700 rounded p-2 flex items-center justify-between">
+                <span>
+                  <span className="text-blue-400">Block {testEnvSession.blockNumber}</span>
+                  {testEnvSession.expiresAt && (
+                    <span className="text-gray-500 ml-1">
+                      · expires {new Date(testEnvSession.expiresAt).toLocaleTimeString()}
+                    </span>
+                  )}
+                </span>
+                <button
+                  type="button"
+                  onClick={onDestroySession}
+                  className="ml-2 text-gray-400 hover:text-gray-200 text-xs underline"
+                  title="Close session early to free up a slot"
+                >
+                  Close
+                </button>
               </div>
+            )}
+            {!testEnvSession && (
+              <div className="text-xs text-gray-500">Sessions last 30 minutes. Max 10 concurrent sessions on the server.</div>
             )}
             {formData.UseTestEnv && !formData.TestEnvBlockNumber && (
               <div className="text-xs text-yellow-400">Enter a block number to query historical state</div>
@@ -684,6 +700,7 @@ PathFinderForm.propTypes = {
   handleTestEnvBlockNumberChange: PropTypes.func.isRequired,
   handleQuantizedModeToggle: PropTypes.func.isRequired,
   testEnvSession: PropTypes.object,
+  onDestroySession: PropTypes.func.isRequired,
   handleDebugIntermediateToggle: PropTypes.func.isRequired,
   handleFromTokensExclusionToggle: PropTypes.func.isRequired,
   handleToTokensExclusionToggle: PropTypes.func.isRequired,

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -34,6 +34,9 @@ const DEFAULTS = {
   Amount: '1000000000000000000000',
   WithWrap: true,
   UseStaging: false,
+  UseTestEnv: false,
+  TestEnvUrl: 'https://staging.circlesubi.network/test-env',
+  TestEnvBlockNumber: '',
   MaxTransfers: '10',
   IsFromTokensExcluded: false,
   IsToTokensExcluded: false,
@@ -202,8 +205,25 @@ export const useFormData = () => {
   const handleStagingToggle = () => {
     setFormData(prev => ({
       ...prev,
-      UseStaging: !prev.UseStaging
+      UseStaging: !prev.UseStaging,
+      UseTestEnv: false // mutually exclusive
     }));
+  };
+
+  const handleTestEnvToggle = () => {
+    setFormData(prev => ({
+      ...prev,
+      UseTestEnv: !prev.UseTestEnv,
+      UseStaging: false // mutually exclusive
+    }));
+  };
+
+  const handleTestEnvUrlChange = (e) => {
+    setFormData(prev => ({ ...prev, TestEnvUrl: e.target.value }));
+  };
+
+  const handleTestEnvBlockNumberChange = (e) => {
+    setFormData(prev => ({ ...prev, TestEnvBlockNumber: e.target.value }));
   };
 
   const handleQuantizedModeToggle = () => {
@@ -365,6 +385,9 @@ export const useFormData = () => {
     handleTokensChange,
     handleWithWrapToggle,
     handleStagingToggle,
+    handleTestEnvToggle,
+    handleTestEnvUrlChange,
+    handleTestEnvBlockNumberChange,
     handleQuantizedModeToggle,
     handleDebugIntermediateToggle,
     handleFromTokensExclusionToggle,

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -9,6 +9,10 @@ function loadSavedForm() {
     if (saved) {
       const parsed = JSON.parse(saved);
       const merged = { ...DEFAULTS, ...parsed };
+      // Test-env requires staging — normalize on load
+      if (merged.UseTestEnv && !merged.UseStaging) {
+        merged.UseStaging = true;
+      }
       console.log('[form-persist] loaded:', {
         FromTokens: merged.FromTokens,
         ToTokens: merged.ToTokens,
@@ -206,7 +210,8 @@ export const useFormData = () => {
     setFormData(prev => ({
       ...prev,
       UseStaging: !prev.UseStaging,
-      UseTestEnv: false // mutually exclusive
+      // Turning off staging also turns off test-env (test-env requires staging)
+      UseTestEnv: !prev.UseStaging ? prev.UseTestEnv : false,
     }));
   };
 
@@ -214,7 +219,8 @@ export const useFormData = () => {
     setFormData(prev => ({
       ...prev,
       UseTestEnv: !prev.UseTestEnv,
-      UseStaging: false // mutually exclusive
+      // Test-env requires staging — auto-enable it
+      UseStaging: !prev.UseTestEnv ? true : prev.UseStaging,
     }));
   };
 

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ethToWei } from '../services/circlesApi';
+import { ethToWei, DEFAULT_TEST_ENV_URL } from '../services/circlesApi';
 
 const STORAGE_KEY = 'flow-viz-form';
 
@@ -35,7 +35,7 @@ const DEFAULTS = {
   WithWrap: true,
   UseStaging: false,
   UseTestEnv: false,
-  TestEnvUrl: 'https://staging.circlesubi.network/test-env',
+  TestEnvUrl: DEFAULT_TEST_ENV_URL,
   TestEnvBlockNumber: '',
   MaxTransfers: '10',
   IsFromTokensExcluded: false,

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -12,6 +12,7 @@ import cacheService from './cacheService';
 
 export const API_ENDPOINT = 'https://rpc.aboutcircles.com/';
 export const STAGING_ENDPOINT = 'https://staging.circlesubi.network/';
+export const DEFAULT_TEST_ENV_URL = 'https://staging.circlesubi.network/test-env';
 
 const fetchTokenBalancesForAddress = async (address) => {
   const res = await fetch(API_ENDPOINT, {
@@ -110,8 +111,12 @@ export const ethToWei = (crcAmount) => {
 };
 
 export const findPath = async (formData, sdkRpc) => {
+  // Test environment mode: route through test-env RPC proxy
+  if (formData.UseTestEnv && formData.testEnvSession) {
+    return findPathViaTestEnv(formData);
+  }
+
   // If staging endpoint requested, create a temporary SDK client for it
-  const endpoint = formData.UseStaging ? STAGING_ENDPOINT : API_ENDPOINT;
   const rpc = formData.UseStaging ? new CirclesRpc(STAGING_ENDPOINT) : sdkRpc;
   try {
     // Include and exclude can coexist when quick-filter sends both
@@ -187,6 +192,84 @@ export const findPath = async (formData, sdkRpc) => {
     console.error('SDK findPath error:', err);
     throw err;
   }
+};
+
+/**
+ * Sends a circlesV2_findPath JSON-RPC call through the test-env RPC proxy.
+ * The proxy adds X-Max-Block-Number header, so the pathfinder uses a block-filtered graph.
+ */
+const findPathViaTestEnv = async (formData) => {
+  const { testEnvSession } = formData;
+  if (!testEnvSession?.rpcProxyUrl) {
+    throw new Error('No active test-env session');
+  }
+
+  const fromTokensArray = formData.IsFromTokensExcluded
+    ? [] : parseAddressList(formData.FromTokens);
+  const excludedFromTokensArray = parseAddressList(formData.ExcludedFromTokens);
+  const toTokensArray = formData.IsToTokensExcluded
+    ? [] : parseAddressList(formData.ToTokens);
+  const excludedToTokensArray = parseAddressList(formData.ExcludedToTokens);
+
+  const flowRequest = {
+    source: normalizeAddress(formData.From),
+    sink: normalizeAddress(formData.To),
+    targetFlow: formData.Amount,
+    withWrap: formData.WithWrap || false,
+    quantizedMode: formData.QuantizedMode || false,
+    debugShowIntermediateSteps: formData.DebugShowIntermediateSteps || false,
+  };
+
+  if (fromTokensArray.length > 0) flowRequest.fromTokens = fromTokensArray;
+  if (toTokensArray.length > 0) flowRequest.toTokens = toTokensArray;
+  if (excludedFromTokensArray.length > 0) flowRequest.excludedFromTokens = excludedFromTokensArray;
+  if (excludedToTokensArray.length > 0) flowRequest.excludedToTokens = excludedToTokensArray;
+  if (formData.MaxTransfers) flowRequest.maxTransfers = Number(formData.MaxTransfers);
+
+  const simulatedBalances = parseJsonArray(formData.SimulatedBalances)
+    .map(e => {
+      const holder = normalizeAddress(e?.holder);
+      const token = normalizeAddress(e?.token);
+      const amount = toValidUint(e?.amount);
+      if (!holder || !token || amount === null) return null;
+      return { holder, token, amount: amount.toString(), isWrapped: e?.isWrapped === true, isStatic: e?.isStatic === true };
+    }).filter(Boolean);
+
+  const simulatedTrusts = parseJsonArray(formData.SimulatedTrusts)
+    .map(e => {
+      const truster = normalizeAddress(e?.truster);
+      const trustee = normalizeAddress(e?.trustee);
+      if (!truster || !trustee) return null;
+      return { truster, trustee };
+    }).filter(Boolean);
+
+  if (simulatedBalances.length > 0) flowRequest.simulatedBalances = simulatedBalances;
+  if (simulatedTrusts.length > 0) flowRequest.simulatedTrusts = simulatedTrusts;
+
+  console.log('Test-env findPath via RPC proxy:', testEnvSession.rpcProxyUrl, flowRequest);
+
+  const response = await fetch(testEnvSession.rpcProxyUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'circlesV2_findPath',
+      params: [flowRequest]
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Test-env RPC error: ${response.status} — ${error}`);
+  }
+
+  const rpcResponse = await response.json();
+  if (rpcResponse?.error) {
+    throw new Error(rpcResponse.error.message || 'RPC error from test-env');
+  }
+
+  return rpcResponse.result;
 };
 
 export const processPath = async (rawPath, sourceAddress) => {

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -275,6 +275,10 @@ const findPathViaTestEnv = async (formData) => {
       throw new Error(rpcResponse.error.message || 'RPC error from test-env');
     }
 
+    if (!rpcResponse.result) {
+      throw new Error('Test-env RPC returned no result — no path found or block has no Circles activity');
+    }
+
     // Note: token metadata and profile enrichment still uses production endpoints.
     // Historical path data is correct, but displayed metadata reflects current state.
     return stringifyBigInts(rpcResponse.result);

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -214,7 +214,7 @@ const findPathViaTestEnv = async (formData) => {
   const flowRequest = {
     source: normalizeAddress(formData.From),
     sink: normalizeAddress(formData.To),
-    targetFlow: formData.Amount,
+    targetFlow: String(BigInt(formData.Amount)),
     withWrap: formData.WithWrap || false,
     quantizedMode: formData.QuantizedMode || false,
     debugShowIntermediateSteps: formData.DebugShowIntermediateSteps || false,
@@ -243,33 +243,45 @@ const findPathViaTestEnv = async (formData) => {
       return { truster, trustee };
     }).filter(Boolean);
 
+  const simulatedConsentedAvatars = dedupeAddresses(
+    parseAddressList(formData.SimulatedConsentedAvatars)
+  );
+
   if (simulatedBalances.length > 0) flowRequest.simulatedBalances = simulatedBalances;
   if (simulatedTrusts.length > 0) flowRequest.simulatedTrusts = simulatedTrusts;
+  if (simulatedConsentedAvatars.length > 0) flowRequest.simulatedConsentedAvatars = simulatedConsentedAvatars;
 
   console.log('Test-env findPath via RPC proxy:', testEnvSession.rpcProxyUrl, flowRequest);
 
-  const response = await fetch(testEnvSession.rpcProxyUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'circlesV2_findPath',
-      params: [flowRequest]
-    })
-  });
+  try {
+    const response = await fetch(testEnvSession.rpcProxyUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'circlesV2_findPath',
+        params: [flowRequest]
+      })
+    });
 
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Test-env RPC error: ${response.status} — ${error}`);
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Test-env RPC error: ${response.status} — ${error}`);
+    }
+
+    const rpcResponse = await response.json();
+    if (rpcResponse?.error) {
+      throw new Error(rpcResponse.error.message || 'RPC error from test-env');
+    }
+
+    // Note: token metadata and profile enrichment still uses production endpoints.
+    // Historical path data is correct, but displayed metadata reflects current state.
+    return stringifyBigInts(rpcResponse.result);
+  } catch (err) {
+    console.error('Test-env findPath error:', err);
+    throw err;
   }
-
-  const rpcResponse = await response.json();
-  if (rpcResponse?.error) {
-    throw new Error(rpcResponse.error.message || 'RPC error from test-env');
-  }
-
-  return rpcResponse.result;
 };
 
 export const processPath = async (rawPath, sourceAddress) => {

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -112,7 +112,10 @@ export const ethToWei = (crcAmount) => {
 
 export const findPath = async (formData, sdkRpc) => {
   // Test environment mode: route through test-env RPC proxy
-  if (formData.UseTestEnv && formData.testEnvSession) {
+  if (formData.UseTestEnv) {
+    if (!formData.testEnvSession) {
+      throw new Error('Test environment is enabled but no active session is attached');
+    }
     return findPathViaTestEnv(formData);
   }
 

--- a/src/services/testEnvService.js
+++ b/src/services/testEnvService.js
@@ -79,8 +79,9 @@ export async function destroySession() {
 
   try {
     await fetch(`${baseUrl}/api/v1/session/${sessionId}`, { method: 'DELETE' });
-  } catch {
-    // Ignore cleanup errors — session will expire via TTL
+  } catch (err) {
+    // Non-fatal — session will expire via TTL, but log for debugging
+    console.warn(`Failed to destroy test-env session ${sessionId}:`, err.message);
   }
 }
 

--- a/src/services/testEnvService.js
+++ b/src/services/testEnvService.js
@@ -1,0 +1,158 @@
+/**
+ * Test Environment session management for historical pathfinding.
+ *
+ * Creates and manages sessions against the Circles test environment,
+ * which proxies RPC calls with X-Max-Block-Number for block-filtered queries.
+ */
+
+const DEFAULT_TEST_ENV_URL = 'https://staging.circlesubi.network/test-env';
+
+let activeSession = null;
+let sessionTimer = null;
+
+/**
+ * Creates a test-env session at the given block number.
+ * Reuses existing session if same block and not expired.
+ */
+export async function getOrCreateSession(testEnvUrl, blockNumber) {
+  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+
+  // Reuse if same block and not expired
+  if (activeSession
+    && activeSession.baseUrl === baseUrl
+    && activeSession.blockNumber === blockNumber
+    && activeSession.expiresAt > new Date()) {
+    return activeSession;
+  }
+
+  // Clean up old session
+  if (activeSession) {
+    await destroySession().catch(() => {});
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      blockNumber: Number(blockNumber),
+      features: ['db', 'rpc'],
+      ttl: '30m'
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Failed to create test-env session: ${response.status} — ${error}`);
+  }
+
+  const session = await response.json();
+
+  activeSession = {
+    ...session,
+    baseUrl,
+    blockNumber: Number(blockNumber),
+    expiresAt: new Date(session.expiresAt),
+    rpcProxyUrl: `${baseUrl}/api/v1/session/${session.sessionId}/rpc`
+  };
+
+  return activeSession;
+}
+
+/**
+ * Sends a JSON-RPC request through the test-env RPC proxy.
+ * The proxy adds X-Max-Block-Number header automatically.
+ */
+export async function sendRpcRequest(method, params) {
+  if (!activeSession) {
+    throw new Error('No active test-env session');
+  }
+
+  const response = await fetch(activeSession.rpcProxyUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method,
+      params
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Test-env RPC error: ${response.status} — ${error}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Destroys the active session.
+ */
+export async function destroySession() {
+  if (!activeSession) return;
+
+  const { baseUrl, sessionId } = activeSession;
+  activeSession = null;
+
+  if (sessionTimer) {
+    clearInterval(sessionTimer);
+    sessionTimer = null;
+  }
+
+  try {
+    await fetch(`${baseUrl}/api/v1/session/${sessionId}`, { method: 'DELETE' });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+/**
+ * Gets the active session info (or null).
+ */
+export function getActiveSession() {
+  if (activeSession && activeSession.expiresAt <= new Date()) {
+    activeSession = null;
+  }
+  return activeSession;
+}
+
+/**
+ * Checks if a block number exists in the test-env database.
+ */
+export async function checkBlockExists(testEnvUrl, blockNumber) {
+  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/blocks/${blockNumber}/exists`);
+    if (!response.ok) return false;
+    const data = await response.json();
+    return data?.exists === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets the latest indexed block from the test-env.
+ */
+export async function getLatestBlock(testEnvUrl) {
+  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  const response = await fetch(`${baseUrl}/api/v1/blocks/current`);
+  if (!response.ok) throw new Error('Failed to get latest block');
+  const data = await response.json();
+  return data?.blockNumber;
+}
+
+/**
+ * Gets the health status of the test-env.
+ */
+export async function getTestEnvHealth(testEnvUrl) {
+  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  try {
+    const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(5000) });
+    if (!response.ok) return null;
+    return response.json();
+  } catch {
+    return null;
+  }
+}

--- a/src/services/testEnvService.js
+++ b/src/services/testEnvService.js
@@ -3,24 +3,28 @@
  *
  * Creates and manages sessions against the Circles test environment,
  * which proxies RPC calls with X-Max-Block-Number for block-filtered queries.
+ *
+ * Note: Post-pathfinding enrichment (token info, profiles, balances) still
+ * uses production endpoints — historical path data is correct, but displayed
+ * metadata reflects current state. This is a known v1 limitation.
  */
 
-const DEFAULT_TEST_ENV_URL = 'https://staging.circlesubi.network/test-env';
+import { DEFAULT_TEST_ENV_URL } from './circlesApi';
 
 let activeSession = null;
-let sessionTimer = null;
 
 /**
  * Creates a test-env session at the given block number.
  * Reuses existing session if same block and not expired.
  */
 export async function getOrCreateSession(testEnvUrl, blockNumber) {
-  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  const baseUrl = resolveBaseUrl(testEnvUrl);
+  const numBlock = Number(blockNumber);
 
   // Reuse if same block and not expired
   if (activeSession
     && activeSession.baseUrl === baseUrl
-    && activeSession.blockNumber === blockNumber
+    && activeSession.blockNumber === numBlock
     && activeSession.expiresAt > new Date()) {
     return activeSession;
   }
@@ -34,7 +38,7 @@ export async function getOrCreateSession(testEnvUrl, blockNumber) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      blockNumber: Number(blockNumber),
+      blockNumber: numBlock,
       features: ['db', 'rpc'],
       ttl: '30m'
     })
@@ -47,43 +51,21 @@ export async function getOrCreateSession(testEnvUrl, blockNumber) {
 
   const session = await response.json();
 
+  if (!session.sessionId) {
+    throw new Error('Server returned session without sessionId');
+  }
+
+  // Explicitly construct — don't spread unknown server fields
   activeSession = {
-    ...session,
+    sessionId: session.sessionId,
     baseUrl,
-    blockNumber: Number(blockNumber),
+    blockNumber: numBlock,
     expiresAt: new Date(session.expiresAt),
-    rpcProxyUrl: `${baseUrl}/api/v1/session/${session.sessionId}/rpc`
+    rpcProxyUrl: `${baseUrl}/api/v1/session/${session.sessionId}/rpc`,
+    status: session.status,
   };
 
   return activeSession;
-}
-
-/**
- * Sends a JSON-RPC request through the test-env RPC proxy.
- * The proxy adds X-Max-Block-Number header automatically.
- */
-export async function sendRpcRequest(method, params) {
-  if (!activeSession) {
-    throw new Error('No active test-env session');
-  }
-
-  const response = await fetch(activeSession.rpcProxyUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method,
-      params
-    })
-  });
-
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Test-env RPC error: ${response.status} — ${error}`);
-  }
-
-  return response.json();
 }
 
 /**
@@ -95,20 +77,15 @@ export async function destroySession() {
   const { baseUrl, sessionId } = activeSession;
   activeSession = null;
 
-  if (sessionTimer) {
-    clearInterval(sessionTimer);
-    sessionTimer = null;
-  }
-
   try {
     await fetch(`${baseUrl}/api/v1/session/${sessionId}`, { method: 'DELETE' });
   } catch {
-    // Ignore cleanup errors
+    // Ignore cleanup errors — session will expire via TTL
   }
 }
 
 /**
- * Gets the active session info (or null).
+ * Gets the active session info (or null if expired/missing).
  */
 export function getActiveSession() {
   if (activeSession && activeSession.expiresAt <= new Date()) {
@@ -121,7 +98,7 @@ export function getActiveSession() {
  * Checks if a block number exists in the test-env database.
  */
 export async function checkBlockExists(testEnvUrl, blockNumber) {
-  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  const baseUrl = resolveBaseUrl(testEnvUrl);
   try {
     const response = await fetch(`${baseUrl}/api/v1/blocks/${blockNumber}/exists`);
     if (!response.ok) return false;
@@ -136,7 +113,7 @@ export async function checkBlockExists(testEnvUrl, blockNumber) {
  * Gets the latest indexed block from the test-env.
  */
 export async function getLatestBlock(testEnvUrl) {
-  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  const baseUrl = resolveBaseUrl(testEnvUrl);
   const response = await fetch(`${baseUrl}/api/v1/blocks/current`);
   if (!response.ok) throw new Error('Failed to get latest block');
   const data = await response.json();
@@ -147,7 +124,7 @@ export async function getLatestBlock(testEnvUrl) {
  * Gets the health status of the test-env.
  */
 export async function getTestEnvHealth(testEnvUrl) {
-  const baseUrl = (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
+  const baseUrl = resolveBaseUrl(testEnvUrl);
   try {
     const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(5000) });
     if (!response.ok) return null;
@@ -155,4 +132,8 @@ export async function getTestEnvHealth(testEnvUrl) {
   } catch {
     return null;
   }
+}
+
+function resolveBaseUrl(testEnvUrl) {
+  return (testEnvUrl || DEFAULT_TEST_ENV_URL).replace(/\/$/, '');
 }

--- a/src/services/testEnvService.js
+++ b/src/services/testEnvService.js
@@ -20,6 +20,9 @@ let activeSession = null;
 export async function getOrCreateSession(testEnvUrl, blockNumber) {
   const baseUrl = resolveBaseUrl(testEnvUrl);
   const numBlock = Number(blockNumber);
+  if (!Number.isInteger(numBlock) || numBlock < 0) {
+    throw new Error('Block number must be a non-negative integer');
+  }
 
   // Reuse if same block and not expired
   if (activeSession
@@ -78,7 +81,11 @@ export async function destroySession() {
   activeSession = null;
 
   try {
-    await fetch(`${baseUrl}/api/v1/session/${sessionId}`, { method: 'DELETE' });
+    const response = await fetch(`${baseUrl}/api/v1/session/${sessionId}`, { method: 'DELETE' });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      console.warn(`Failed to destroy test-env session ${sessionId}: HTTP ${response.status}${detail ? ` — ${detail}` : ''}`);
+    }
   } catch (err) {
     // Non-fatal — session will expire via TTL, but log for debugging
     console.warn(`Failed to destroy test-env session ${sessionId}:`, err.message);


### PR DESCRIPTION
## Summary

- Adds a "Test Environment" toggle to the path builder form for querying the pathfinder against historical blockchain state at a specific block number
- Auto-creates test-env sessions, reuses across queries, shows session status (block, expiry)
- Routes `circlesV2_findPath` calls through the test-env RPC proxy (which adds `X-Max-Block-Number` header)
- Mutually exclusive with staging mode

### New files
- `testEnvService.js` — session lifecycle management (create, destroy, health, block check)

### Key details
- BigInt-safe response handling via `stringifyBigInts`
- All `FlowRequest` parameters supported including `simulatedConsentedAvatars`
- Null-result guard for empty RPC responses
- Single source of truth for `DEFAULT_TEST_ENV_URL`
- Session object explicitly constructed (no server field collision risk)

### Known v1 limitations (documented in code)
- Post-pathfinding enrichment (token info, profiles) still uses production endpoints
- No abort/cancellation on concurrent requests (pre-existing pattern)

### Related PRs
- aboutcircles/circles-nethermind-plugin#337 — pathfinder X-Max-Block-Number support
- aboutcircles/circles-test-environment#2 — RPC proxy controller

## Test plan
- [ ] Toggle "Test Environment" — block number and URL fields appear
- [ ] Enter block number, click Find Path — session created, path computed
- [ ] Session status shows block number and expiry time
- [ ] Second query at same block reuses session (no new creation)
- [ ] Changing block number creates new session
- [ ] Invalid block number shows error warning
- [ ] Toggling staging disables test-env (mutually exclusive)