### PR TITLE
fix: prevent crash when source and sink addresses are identical

### DIFF
--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useFormData } from '@/hooks/useFormData';
+import { useFormData, isAddress } from '@/hooks/useFormData';
 import { usePathData } from '@/hooks/usePathData';
 import { usePersistedState } from '@/hooks/usePersistedState';
 import { usePerformance } from '@/contexts/PerformanceContext';
@@ -423,8 +423,13 @@ const FlowVisualization = () => {
   const hasAutoRun = useRef(false);
   useEffect(() => {
     if (hasAutoRun.current) return;
-    const isAddress = (v) => typeof v === 'string' && /^0x[a-fA-F0-9]{40}$/.test(v.trim());
-    if (isAddress(formData.From) && isAddress(formData.To) && formData.Amount && formData.Amount !== '0') {
+    if (
+      isAddress(formData.From) &&
+      isAddress(formData.To) &&
+      formData.From.toLowerCase() !== formData.To.toLowerCase() &&
+      formData.Amount &&
+      formData.Amount !== '0'
+    ) {
       hasAutoRun.current = true;
       handleFindPath();
     }
@@ -643,13 +648,18 @@ const FlowVisualization = () => {
 
   // Decompose into routes when pathData changes
   useEffect(() => {
-    if (!pathData || !formData.From || !formData.To) {
+    if (!pathData || !Array.isArray(pathData.transfers) || !formData.From || !formData.To) {
       setRoutes([]);
       setSelectedRouteIds(new Set());
       return;
     }
     const source = formData.From.toLowerCase();
     const sink = formData.To.toLowerCase();
+    if (source === sink) {
+      setRoutes([]);
+      setSelectedRouteIds(new Set());
+      return;
+    }
     const decomposed = decomposeFlow(pathData.transfers, source, sink);
     setRoutes(decomposed);
     setSelectedRouteIds(new Set(decomposed.map(r => r.id)));

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -9,6 +9,11 @@ function loadSavedForm() {
     if (saved) {
       const parsed = JSON.parse(saved);
       const merged = { ...DEFAULTS, ...parsed };
+      // Sanitize: reset To if it equals From to avoid crash loop
+      if (merged.From?.toLowerCase?.() === merged.To?.toLowerCase?.()) {
+        merged.To = DEFAULTS.To;
+        console.warn('[form-persist] sanitized: reset To to default because From === To');
+      }
       console.log('[form-persist] loaded:', {
         FromTokens: merged.FromTokens,
         ToTokens: merged.ToTokens,
@@ -44,7 +49,7 @@ const DEFAULTS = {
   SimulatedConsentedAvatars: '',
 };
 
-const isAddress = (value) => typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value.trim());
+export const isAddress = (value) => typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value.trim());
 
 const parseTokenSet = (value) => new Set(
   (value || '')
@@ -224,8 +229,13 @@ export const useFormData = () => {
     const nextErrors = {};
     const nextWarnings = [];
 
-    if (!isAddress(candidateFormData?.From)) nextErrors.From = 'Source must be a valid 0x address';
-    if (!isAddress(candidateFormData?.To)) nextErrors.To = 'Sink must be a valid 0x address';
+    const fromValid = isAddress(candidateFormData?.From);
+    const toValid = isAddress(candidateFormData?.To);
+    if (!fromValid) nextErrors.From = 'Source must be a valid 0x address';
+    if (!toValid) nextErrors.To = 'Sink must be a valid 0x address';
+    if (fromValid && toValid && candidateFormData.From.toLowerCase() === candidateFormData.To.toLowerCase()) {
+      nextErrors.To = 'Source and sink must be different';
+    }
 
     try {
       const target = BigInt(candidateFormData?.Amount || '0');

--- a/src/utils/flowDecomposition.js
+++ b/src/utils/flowDecomposition.js
@@ -34,7 +34,7 @@ export function decomposeFlow(transfers, source, sink) {
 
     // DFS to find a path from source to sink
     const path = dfsPath(adj, source, sink);
-    if (!path) break;
+    if (!path || path.length === 0) break;
 
     // Flow = min capacity along the path
     const flow = path.reduce(
@@ -70,6 +70,8 @@ export function decomposeFlow(transfers, source, sink) {
 }
 
 function dfsPath(adj, source, sink) {
+  if (source === sink) return null;
+
   const visited = new Set();
   const path = [];
 


### PR DESCRIPTION
## Summary
Fixes a white-screen crash that occurs when users set the same address for both **From** and **To** fields.

## Root Cause
1. `dfsPath()` in `flowDecomposition.js` returned an empty array `[]` when `source === sink`, which passed the `if (!path)` guard and then crashed on `path[0].capacity`.
2. The form state auto-persists to `localStorage`, and the app auto-runs `findPath` on mount. This created a crash loop: user sets same address → crash → reload → same state restored → crash again.

## Changes
- **`src/utils/flowDecomposition.js`**: `dfsPath` returns `null` when `source === sink`; added defensive `path.length === 0` guard.
- **`src/hooks/useFormData.js`**: Added form validation (`From !== To`); sanitize persisted `localStorage` state on load to auto-recover trapped users.
- **`src/components/FlowVisualization.jsx`**: Hardened mount auto-run to skip when `From === To`.

## Testing
- Unit-tested `decomposeFlow` with same source/sink → returns `[]` without throwing.
- Verified validation rejects identical addresses (case-insensitive).
- Verified `loadSavedForm` sanitizes broken persisted state.