### PR TITLE
fix: allow self-transfers (source === sink) in pathfinder

### DIFF
--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useFormData, isAddress } from '@/hooks/useFormData';
+import { useFormData } from '@/hooks/useFormData';
 import { usePathData } from '@/hooks/usePathData';
 import { usePersistedState } from '@/hooks/usePersistedState';
 import { usePerformance } from '@/contexts/PerformanceContext';
@@ -423,13 +423,8 @@ const FlowVisualization = () => {
   const hasAutoRun = useRef(false);
   useEffect(() => {
     if (hasAutoRun.current) return;
-    if (
-      isAddress(formData.From) &&
-      isAddress(formData.To) &&
-      formData.From.toLowerCase() !== formData.To.toLowerCase() &&
-      formData.Amount &&
-      formData.Amount !== '0'
-    ) {
+    const isAddress = (v) => typeof v === 'string' && /^0x[a-fA-F0-9]{40}$/.test(v.trim());
+    if (isAddress(formData.From) && isAddress(formData.To) && formData.Amount && formData.Amount !== '0') {
       hasAutoRun.current = true;
       handleFindPath();
     }
@@ -655,11 +650,6 @@ const FlowVisualization = () => {
     }
     const source = formData.From.toLowerCase();
     const sink = formData.To.toLowerCase();
-    if (source === sink) {
-      setRoutes([]);
-      setSelectedRouteIds(new Set());
-      return;
-    }
     const decomposed = decomposeFlow(pathData.transfers, source, sink);
     setRoutes(decomposed);
     setSelectedRouteIds(new Set(decomposed.map(r => r.id)));

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -9,11 +9,6 @@ function loadSavedForm() {
     if (saved) {
       const parsed = JSON.parse(saved);
       const merged = { ...DEFAULTS, ...parsed };
-      // Sanitize: reset To if it equals From to avoid crash loop
-      if (merged.From?.toLowerCase?.() === merged.To?.toLowerCase?.()) {
-        merged.To = DEFAULTS.To;
-        console.warn('[form-persist] sanitized: reset To to default because From === To');
-      }
       console.log('[form-persist] loaded:', {
         FromTokens: merged.FromTokens,
         ToTokens: merged.ToTokens,
@@ -49,7 +44,7 @@ const DEFAULTS = {
   SimulatedConsentedAvatars: '',
 };
 
-export const isAddress = (value) => typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value.trim());
+const isAddress = (value) => typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value.trim());
 
 const parseTokenSet = (value) => new Set(
   (value || '')
@@ -229,13 +224,8 @@ export const useFormData = () => {
     const nextErrors = {};
     const nextWarnings = [];
 
-    const fromValid = isAddress(candidateFormData?.From);
-    const toValid = isAddress(candidateFormData?.To);
-    if (!fromValid) nextErrors.From = 'Source must be a valid 0x address';
-    if (!toValid) nextErrors.To = 'Sink must be a valid 0x address';
-    if (fromValid && toValid && candidateFormData.From.toLowerCase() === candidateFormData.To.toLowerCase()) {
-      nextErrors.To = 'Source and sink must be different';
-    }
+    if (!isAddress(candidateFormData?.From)) nextErrors.From = 'Source must be a valid 0x address';
+    if (!isAddress(candidateFormData?.To)) nextErrors.To = 'Sink must be a valid 0x address';
 
     try {
       const target = BigInt(candidateFormData?.Amount || '0');


### PR DESCRIPTION
## Summary
Reverts the overly restrictive guards from #17 that incorrectly blocked self-transfers.

## Problem
PR #17 added form validation and guards that rejected `From === To`, but the pathfinder API actually supports self-transfers. The only component that couldn't handle them was the flow route decomposition (`dfsPath`), which crashed on `path[0].capacity`.

## Changes
- **Remove** form validation: "Source and sink must be different"
- **Remove** localStorage sanitization that reset `To` when it matched `From`
- **Remove** auto-run hardening that skipped when `From === To`
- **Remove** `source === sink` guard before route decomposition
- **Keep** the `dfsPath` null guard (the actual crash fix)
- **Keep** the `Array.isArray(pathData.transfers)` defensive check

## Behavior
- Self-transfers now work: pathfinder runs, transfers display in graph
- Route decomposition returns `[]` for self-transfers (no meaningful source→sink routes exist)
- No crash, no validation error