### PR TITLE
Point staging endpoint to rpc.staging.aboutcircles.com

### DIFF
--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -356,7 +356,7 @@ const PathFinderForm = ({
             onToggle={handleStagingToggle}
             label="Use Staging Endpoint"
           />
-          <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: staging.circlesubi.network\n\nCurrently using: ${formData.UseStaging ? 'staging.circlesubi.network' : 'rpc.aboutcircles.com'}`} />
+          <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: rpc.staging.aboutcircles.com\n\nCurrently using: ${formData.UseStaging ? 'rpc.staging.aboutcircles.com' : 'rpc.aboutcircles.com'}`} />
         </div>
         <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
           <ToggleSwitch

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -11,7 +11,7 @@ import { encodeFunctionData, concatHex } from 'viem';
 import cacheService from './cacheService';
 
 export const API_ENDPOINT = 'https://rpc.aboutcircles.com/';
-export const STAGING_ENDPOINT = 'https://staging.circlesubi.network/';
+export const STAGING_ENDPOINT = 'https://rpc.staging.aboutcircles.com/';
 
 const fetchTokenBalancesForAddress = async (address) => {
   const res = await fetch(API_ENDPOINT, {


### PR DESCRIPTION
## Summary
- Switch the staging RPC URL from `staging.circlesubi.network` to `rpc.staging.aboutcircles.com`.
- Both hostnames serve the same staging backend; this consolidates onto the `aboutcircles.com` domain.

## Test plan
- [ ] With the toggle off, requests go to `rpc.aboutcircles.com` (prod) — unchanged.
- [ ] With "Use Staging Endpoint" on, the network panel shows POSTs to `rpc.staging.aboutcircles.com`.
- [ ] InfoTip text reflects the new staging hostname.