### PR TITLE
feat: EIP-55 checksums, BFS layout, keyboard shortcut, node menu, undo removal

### DIFF
--- a/src/components/CytoscapeVisualization.jsx
+++ b/src/components/CytoscapeVisualization.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { checksumAddr } from '@/lib/utils';
 import { useCytoscape } from '@/hooks/useCytoscape';
 import { usePerformance } from '@/contexts/PerformanceContext';
+import { usePersistedState } from '@/hooks/usePersistedState';
 import { Button } from '@/components/ui/button';
 import { 
   ZoomIn, 
@@ -32,7 +34,8 @@ const CytoscapeVisualization = forwardRef(({
 }, ref) => {
   const containerRef = useRef(null);
   const [tooltip, setTooltip] = useState({ text: '', position: null });
-  const [layoutName, setLayoutName] = useState('klay');
+  const [nodeMenu, setNodeMenu] = useState(null); // { id, position, isIntermediate }
+  const [layoutName, setLayoutName] = usePersistedState('graph-layout', 'bfs-tiered');
   const [highlightedPath, setHighlightedPath] = useState(null);
   const { config } = usePerformance();
   
@@ -61,6 +64,7 @@ const CytoscapeVisualization = forwardRef(({
     onTooltip: setTooltip,
     onTransactionSelect,
     onNodeRemove,
+    onNodeMenu: setNodeMenu,
     layoutName,
     showNames
   });
@@ -177,6 +181,7 @@ const CytoscapeVisualization = forwardRef(({
               onChange={(e) => handleLayoutChange(e.target.value)}
               className="text-sm border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
+              <option value="bfs-tiered">BFS Tiered</option>
               <option value="klay">Klay</option>
               <option value="hierarchical">Hierarchical</option>
               <option value="dagre">Dagre</option>
@@ -212,6 +217,43 @@ const CytoscapeVisualization = forwardRef(({
         </div>
       )}
       
+      {/* Node context menu */}
+      {nodeMenu && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setNodeMenu(null)} />
+          <div
+            className="absolute z-50 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[170px]"
+            style={{ left: nodeMenu.position.x + 8, top: nodeMenu.position.y + 8 }}
+          >
+            <div className="px-3 py-1.5 text-[10px] text-gray-400 border-b border-gray-100 font-mono">
+              {checksumAddr(nodeMenu.id)}
+            </div>
+            <button
+              type="button"
+              className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center gap-2"
+              onClick={() => {
+                navigator.clipboard.writeText(checksumAddr(nodeMenu.id)).catch(() => {});
+                setNodeMenu(null);
+              }}
+            >
+              <span>📋</span> Copy Address
+            </button>
+            {nodeMenu.isIntermediate && onNodeRemove && (
+              <button
+                type="button"
+                className="w-full text-left px-3 py-2 text-sm hover:bg-red-50 text-red-600 flex items-center gap-2"
+                onClick={() => {
+                  onNodeRemove(nodeMenu.id);
+                  setNodeMenu(null);
+                }}
+              >
+                <span>✕</span> Remove from Graph
+              </button>
+            )}
+          </div>
+        </>
+      )}
+
       {/* Tooltip */}
       {tooltip.text && tooltip.position && (
         <div

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -9,6 +9,7 @@ import { useAccount, useConnect, useDisconnect, useSwitchChain, useWriteContract
 import { gnosis } from "wagmi/chains";
 import { HUB_ADDRESS } from "@/config/wagmi";
 import { buildSafeFlowMatrixSimulationTx } from "@/services/circlesApi";
+import CopyableAddress from "@/components/ui/copyable-address";
 
 // Just the operateFlowMatrix function ABI
 const OPERATE_FLOW_MATRIX_ABI = [
@@ -540,7 +541,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
 
         {isConnected && (
           <div className="mb-2 text-sm text-gray-600">
-            Connected: {address?.slice(0, 6)}...{address?.slice(-4)}
+            Connected: <CopyableAddress address={address} />
             {chain && ` (${chain.name})`}
           </div>
         )}

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -16,6 +16,8 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, GripHorizontal, User, Hash } from 'lucide-react';
+import { checksumAddr } from '@/lib/utils';
+import CopyableAddress from '@/components/ui/copyable-address';
 import InfoTip from '@/components/ui/info-tip';
 import PathStats from '@/components/PathStats';
 
@@ -640,6 +642,7 @@ const FlowVisualization = () => {
   // --- Route-based flow decomposition ---
   const [routes, setRoutes] = useState([]);
   const [selectedRouteIds, setSelectedRouteIds] = useState(new Set());
+  const [removalHistory, setRemovalHistory] = useState([]); // undo stack for node removals
 
   // Decompose into routes when pathData changes
   useEffect(() => {
@@ -653,6 +656,7 @@ const FlowVisualization = () => {
     const decomposed = decomposeFlow(pathData.transfers, source, sink);
     setRoutes(decomposed);
     setSelectedRouteIds(new Set(decomposed.map(r => r.id)));
+    setRemovalHistory([]);
   }, [pathData, formData.From, formData.To]);
 
   // Skip next slider effect after manual toggle (prevents overwrite)
@@ -718,18 +722,14 @@ const FlowVisualization = () => {
     if (id === source || id === sink) return;
 
     resetSliderToFull();
-    setSelectedRouteIds(prev => {
-      const next = new Set(prev);
-      for (const route of routes) {
-        if (!next.has(route.id)) continue;
-        const passesThrough = route.edges.some(
-          e => e.from === id || e.to === id
-        );
-        if (passesThrough) next.delete(route.id);
-      }
-      return next;
-    });
-  }, [routes, formData, resetSliderToFull]);
+    const next = new Set(selectedRouteIds);
+    for (const route of routes) {
+      if (!next.has(route.id)) continue;
+      if (route.edges.some(e => e.from === id || e.to === id)) next.delete(route.id);
+    }
+    setRemovalHistory(h => [...h, selectedRouteIds]);
+    setSelectedRouteIds(next);
+  }, [routes, formData, resetSliderToFull, selectedRouteIds]);
 
   // Build filtered path data from selected routes
   const filteredPathData = useMemo(() => {
@@ -879,6 +879,24 @@ const FlowVisualization = () => {
                     className="rounded-l-none"
                   >
                     Sankey
+                  </Button>
+                </div>
+              )}
+
+              {/* Undo node removal */}
+              {removalHistory.length > 0 && (
+                <div className="absolute top-14 right-4 z-10">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="bg-white shadow-sm text-xs gap-1.5"
+                    onClick={() => {
+                      const prev = removalHistory[removalHistory.length - 1];
+                      setSelectedRouteIds(prev);
+                      setRemovalHistory(h => h.slice(0, -1));
+                    }}
+                  >
+                    ↩ Undo removal
                   </Button>
                 </div>
               )}
@@ -1163,13 +1181,12 @@ const FlowVisualization = () => {
                                       const cadence = typeof row?.isInflationary === 'boolean' ? (row.isInflationary ? 'Static' : 'Demurraged') : null;
                                       const ownerAddress = row?.tokenOwner || '';
                                       const ownerProfile = tokenOwnerProfiles?.[ownerAddress.toLowerCase()];
-                                      const ownerDisplay = showNames ? (ownerProfile?.name || `${ownerAddress.slice(0, 6)}…${ownerAddress.slice(-4)}`) : `${ownerAddress.slice(0, 6)}…${ownerAddress.slice(-4)}`;
 
                                       return (
                                         <tr key={`${row.tokenAddress}-${row.tokenOwner}`} className="hover:bg-gray-50">
                                           <td className="px-3 py-2"><input type="checkbox" checked={isQuickTokenSelected(row.tokenAddress)} onChange={() => toggleQuickToken(row.tokenAddress)} className="rounded border-gray-300" title="Include this source token in quick fromTokens filter" /></td>
-                                          <td className="px-3 py-2 font-mono text-[11px] text-gray-700">{row.tokenAddress?.slice(0, 6)}…{row.tokenAddress?.slice(-4)}</td>
-                                          <td className={`px-3 py-2 text-[11px] text-gray-600 ${showNames ? '' : 'font-mono'}`}>{ownerDisplay}</td>
+                                          <td className="px-3 py-2 text-[11px] text-gray-700"><CopyableAddress address={row.tokenAddress} /></td>
+                                          <td className="px-3 py-2 text-[11px] text-gray-600"><CopyableAddress address={ownerAddress} label={showNames && ownerProfile?.name ? ownerProfile.name : undefined} className={showNames && ownerProfile?.name ? '' : 'font-mono'} /></td>
                                           <td className="px-3 py-2 text-right text-gray-700">{formatBalanceNum(row.circles)}</td>
                                           <td className="px-3 py-2 text-right text-gray-700">{formatBalanceNum(row.staticCircles)}</td>
                                           <td className="px-3 py-2">
@@ -1228,14 +1245,11 @@ const FlowVisualization = () => {
                                     {sinkTrustRows.map((row) => {
                                       const avatarAddress = row?.tokenAddress || '';
                                       const profile = tokenOwnerProfiles?.[avatarAddress.toLowerCase()];
-                                      const avatarDisplay = showNames
-                                        ? (profile?.name || `${avatarAddress.slice(0, 6)}…${avatarAddress.slice(-4)}`)
-                                        : `${avatarAddress.slice(0, 6)}…${avatarAddress.slice(-4)}`;
                                       return (
                                         <tr key={avatarAddress} className="hover:bg-gray-50">
                                           <td className="px-3 py-2"><input type="checkbox" checked={isQuickSinkTokenSelected(avatarAddress)} onChange={() => toggleQuickSinkToken(avatarAddress)} className="rounded border-gray-300" title="Include this sink-trusted avatar in quick toTokens filter" /></td>
-                                          <td className="px-3 py-2 font-mono text-[11px] text-gray-700">{avatarAddress.slice(0, 6)}…{avatarAddress.slice(-4)}</td>
-                                          <td className={`px-3 py-2 text-[11px] text-gray-600 ${showNames ? '' : 'font-mono'}`}>{avatarDisplay}</td>
+                                          <td className="px-3 py-2 text-[11px] text-gray-700"><CopyableAddress address={avatarAddress} /></td>
+                                          <td className="px-3 py-2 text-[11px] text-gray-600"><CopyableAddress address={avatarAddress} label={showNames && profile?.name ? profile.name : undefined} className={showNames && profile?.name ? '' : 'font-mono'} /></td>
                                           <td className="px-3 py-2 text-right text-gray-700">{row.relation || 'trusts'}</td>
                                         </tr>
                                       );

--- a/src/components/GraphControls.jsx
+++ b/src/components/GraphControls.jsx
@@ -22,6 +22,7 @@ const GraphControls = ({
   const [showLayoutMenu, setShowLayoutMenu] = useState(false);
 
   const layouts = [
+    { id: 'bfs-tiered', name: 'BFS Tiered', description: 'Source → tiers → sink columns' },
     { id: 'klay', name: 'Klay (Hierarchical)', description: 'Best for flow visualization' },
     { id: 'dagre', name: 'Dagre (Layered)', description: 'Clear left-to-right flow' },
     { id: 'breadthfirst', name: 'Breadth First', description: 'Tree-like structure' },

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -75,6 +75,7 @@ const PathFinderForm = ({
 }) => {
   const fromTokensRef = useRef(null);
   const toTokensRef = useRef(null);
+  const handleFindPathRef = useRef(null);
   const [isSimulationEditorOpen, setIsSimulationEditorOpen] = useState(false);
   const [simulationBalanceRows, setSimulationBalanceRows] = useState([]);
   const [simulationTrustRows, setSimulationTrustRows] = useState([]);
@@ -277,6 +278,21 @@ const PathFinderForm = ({
     onFindPath(fromPending || toPending ? patched : undefined);
   };
 
+  // Keep ref current so the keyboard handler always calls the latest version
+  handleFindPathRef.current = handleFindPath;
+
+  useEffect(() => {
+    if (isSimulationEditorOpen) return; // simulation editor owns Ctrl+Enter while open
+    const onKeyDown = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && !isLoading) {
+        e.preventDefault();
+        handleFindPathRef.current();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isSimulationEditorOpen, isLoading]);
+
   return (
     <Card>
       <CardContent className="space-y-4 pt-4">
@@ -472,7 +488,7 @@ const PathFinderForm = ({
           onClick={handleFindPath}
           disabled={isLoading}
         >
-          {isLoading ? 'Finding Path...' : 'Find Path'}
+          {isLoading ? 'Finding Path...' : 'Find Path  ⌘↵'}
         </Button>
 
         {isSimulationEditorOpen && typeof document !== 'undefined' && createPortal(

--- a/src/components/PathStats.jsx
+++ b/src/components/PathStats.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card } from '@/components/ui/card';
 import { calculateAllMetrics } from '@/components/metrics';
+import { checksumAddr } from '@/lib/utils';
 
 const shortAddr = (addr) => `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 
@@ -10,9 +11,9 @@ const RouteSelector = ({ routes, selectedRouteIds, onToggleRoute, onToggleAllRou
   const someSelected = selectedRouteIds.size > 0 && selectedRouteIds.size < routes.length;
 
   const displayAddr = (addr) => {
-    if (!showNames || !nodeProfiles) return shortAddr(addr);
+    if (!showNames || !nodeProfiles) return shortAddr(checksumAddr(addr));
     const profile = nodeProfiles[addr.toLowerCase()];
-    if (!profile?.name) return shortAddr(addr);
+    if (!profile?.name) return shortAddr(checksumAddr(addr));
     const name = profile.name;
     return name.length > 16 ? name.slice(0, 15) + '…' : name;
   };

--- a/src/components/ui/copyable-address.jsx
+++ b/src/components/ui/copyable-address.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { checksumAddr } from '@/lib/utils';
+
+// Shows address (or optional label), copies full checksummed address on click.
+export default function CopyableAddress({ address, label, className = '' }) {
+  const [copied, setCopied] = useState(false);
+  if (!address) return null;
+  const full = checksumAddr(address);
+  const display = label ?? `${full.slice(0, 6)}…${full.slice(-4)}`;
+
+  const handleClick = (e) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(full).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={`${full}\n(click to copy)`}
+      className={`cursor-pointer hover:text-blue-600 transition-colors ${copied ? 'text-green-600' : ''} ${className}`}
+    >
+      {copied ? '✓' : display}
+    </button>
+  );
+}

--- a/src/components/ui/info-tip.jsx
+++ b/src/components/ui/info-tip.jsx
@@ -1,24 +1,31 @@
-import React, { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { Info } from 'lucide-react';
 
 const InfoTip = ({ text, size = 14 }) => {
-  const [visible, setVisible] = useState(false);
-  const [position, setPosition] = useState('below');
+  const [tooltipStyle, setTooltipStyle] = useState(null);
   const buttonRef = useRef(null);
 
   const show = useCallback(() => {
-    if (buttonRef.current) {
-      const rect = buttonRef.current.getBoundingClientRect();
-      // Show below only if too close to top of viewport, above otherwise
-      setPosition(rect.top < 120 ? 'below' : 'above');
-    }
-    setVisible(true);
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const useAbove = spaceBelow < 120 && rect.top > 120;
+    setTooltipStyle({
+      position: 'fixed',
+      left: rect.left + rect.width / 2,
+      ...(useAbove
+        ? { bottom: window.innerHeight - rect.top + 8 }
+        : { top: rect.bottom + 8 }),
+      transform: 'translateX(-50%)',
+      width: 'min(240px, 60vw)',
+      zIndex: 9999,
+    });
   }, []);
 
-  const hide = useCallback(() => setVisible(false), []);
+  const hide = useCallback(() => setTooltipStyle(null), []);
 
   return (
-    <span className="relative inline-flex items-center ml-1">
+    <span className="relative inline-flex items-center ml-1 align-middle">
       <button
         ref={buttonRef}
         type="button"
@@ -31,13 +38,11 @@ const InfoTip = ({ text, size = 14 }) => {
       >
         <Info size={size} />
       </button>
-      {visible && (
+      {tooltipStyle && (
         <span
           role="tooltip"
-          className={`absolute z-50 block bg-gray-900 text-white text-xs rounded-lg px-3 py-2 shadow-lg pointer-events-none ${
-            position === 'above' ? 'bottom-full mb-2' : 'top-full mt-2'
-          }`}
-          style={{ left: '50%', transform: 'translateX(-50%)', width: 'min(240px, 60vw)' }}
+          className="block bg-gray-900 text-white text-xs rounded-lg px-3 py-2 shadow-lg pointer-events-none"
+          style={tooltipStyle}
         >
           {text}
         </span>

--- a/src/components/ui/transaction_table.jsx
+++ b/src/components/ui/transaction_table.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { checksumAddr } from '@/lib/utils';
+import CopyableAddress from '@/components/ui/copyable-address';
 
 const TransactionTable = ({
   routes,
@@ -39,9 +41,9 @@ const TransactionTable = ({
   const shortAddr = (addr) => `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 
   const displayAddr = (addr) => {
-    if (!showNames || !nodeProfiles) return shortAddr(addr);
+    if (!showNames || !nodeProfiles) return shortAddr(checksumAddr(addr));
     const profile = nodeProfiles[addr.toLowerCase()];
-    if (!profile?.name) return shortAddr(addr);
+    if (!profile?.name) return shortAddr(checksumAddr(addr));
     const name = profile.name;
     return name.length > 16 ? name.slice(0, 15) + '…' : name;
   };
@@ -168,11 +170,11 @@ const TransactionTable = ({
                       <td></td>
                       <td className="pl-6 pr-2 py-2 text-gray-300">↳</td>
                       <td className="px-4 py-2 break-all" colSpan={2}>
-                        <span className={`text-gray-500 ${showNames ? '' : 'font-mono'}`}>{displayAddr(edge.from)}</span>
+                        <CopyableAddress address={edge.from} label={showNames ? nodeProfiles?.[edge.from?.toLowerCase()]?.name : undefined} className="text-gray-500 text-xs" />
                         <span className="mx-1 text-gray-400">→</span>
-                        <span className={`text-gray-500 ${showNames ? '' : 'font-mono'}`}>{displayAddr(edge.to)}</span>
+                        <CopyableAddress address={edge.to} label={showNames ? nodeProfiles?.[edge.to?.toLowerCase()]?.name : undefined} className="text-gray-500 text-xs" />
                         <span className="ml-2 text-gray-400">token:</span>
-                        <span className="ml-1 text-gray-500 font-mono">{shortAddr(edge.tokenOwner)}</span>
+                        <CopyableAddress address={edge.tokenOwner} className="ml-1 text-gray-500 text-xs" />
                         {renderTokenBadges(edge)}
                       </td>
                       <td className="px-4 py-2 text-gray-500">{formatValue(edge.flow)}</td>

--- a/src/components/visualizations/SankeyVisualization.jsx
+++ b/src/components/visualizations/SankeyVisualization.jsx
@@ -12,6 +12,7 @@ import {
   X
 } from 'lucide-react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
+import { checksumAddr } from '@/lib/utils';
 
 const SankeyVisualization = forwardRef(({ 
   pathData,
@@ -290,7 +291,11 @@ const SankeyVisualization = forwardRef(({
     }
 
     // Prepare node labels
-    const shortAddr = (addr) => addr.startsWith('0x') ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : addr;
+    const shortAddr = (addr) => {
+      if (!addr?.startsWith('0x')) return addr || '';
+      const cs = checksumAddr(addr);
+      return `${cs.slice(0, 6)}...${cs.slice(-4)}`;
+    };
     const nodesWithLabels = nodes.map(node => {
       const profile = nodeProfiles[node.realAddress];
       let label = (showNames && profile?.name) ? profile.name : shortAddr(node.realAddress);

--- a/src/hooks/useCytoscape.js
+++ b/src/hooks/useCytoscape.js
@@ -3,6 +3,33 @@ import cytoscape from 'cytoscape';
 import klay from 'cytoscape-klay';
 import dagre from 'cytoscape-dagre';
 import { usePerformance } from '@/contexts/PerformanceContext';
+import { checksumAddr } from '@/lib/utils';
+
+function computeBFSLayers(transfers, source, sink) {
+  const adj = {};
+  for (const t of transfers) {
+    const from = t.from.toLowerCase();
+    const to = t.to.toLowerCase();
+    (adj[from] ||= new Set()).add(to);
+  }
+  const layer = { [source]: 0 };
+  const queue = [source];
+  while (queue.length) {
+    const n = queue.shift();
+    for (const next of (adj[n] || [])) {
+      if (!(next in layer)) { layer[next] = layer[n] + 1; queue.push(next); }
+    }
+  }
+  // Sink must be the rightmost layer — beyond every non-sink node
+  if (sink && sink in layer) {
+    const maxNonSink = Math.max(
+      ...Object.entries(layer).filter(([k]) => k !== sink).map(([, v]) => v),
+      0
+    );
+    layer[sink] = maxNonSink + 1;
+  }
+  return layer;
+}
 
 // Register layout extensions
 cytoscape.use(klay);
@@ -24,12 +51,14 @@ export const useCytoscape = ({
   onTooltip,
   onTransactionSelect,
   onNodeRemove,
-  layoutName = 'klay',
+  onNodeMenu,
+  layoutName = 'bfs-tiered',
   showNames = true
 }) => {
   const cyRef = useRef(null);
   const isInitializingRef = useRef(false);
   const onNodeRemoveRef = useRef(onNodeRemove);
+  const bfsNodePositionsRef = useRef({});
   const nodeProfilesRef = useRef(nodeProfiles);
   const tokenOwnerProfilesRef = useRef(tokenOwnerProfiles);
   const balancesByAccountRef = useRef(balancesByAccount);
@@ -229,12 +258,42 @@ export const useCytoscape = ({
       // Add label
       if (config.rendering.features.nodeLabels) {
         const profile = nodeProfiles[id];
-        const shortAddr = `${id.slice(0, 6)}...${id.slice(-4)}`;
+        const displayId = checksumAddr(id);
+        const shortAddr = `${displayId.slice(0, 6)}...${displayId.slice(-4)}`;
         nodeData.label = (showNames && profile?.name) ? profile.name : shortAddr;
       }
 
       return { data: nodeData };
     });
+
+    // Compute BFS-tier positions (stored in ref so runLayout can reuse them)
+    {
+      // Use graph-theoretic source for BFS — the form's From may not be in the transfer graph
+      const bfsSource = onlySourceAddresses[0] || finalSource;
+      const bfsSink = onlySinkAddresses[0] || finalSink;
+      const bfsLayers = computeBFSLayers(pathData.transfers, bfsSource, bfsSink);
+      const layerGroups = {};
+      Array.from(connectedNodes).forEach(id => {
+        const l = bfsLayers[id] ?? 0;
+        (layerGroups[l] ||= []).push(id);
+      });
+      const layerXSpacing = 220;
+      const nodeYSpacing = 80;
+      const positions = {};
+      const sortedLayers = Object.entries(layerGroups).sort(([a], [b]) => +a - +b);
+      const sourceLayer = 0;
+      const sinkLayer = sortedLayers[sortedLayers.length - 1]?.[0];
+      sortedLayers.forEach(([layer, ids]) => {
+        const x = +layer * layerXSpacing;
+        const isEndpoint = layer === String(sourceLayer) || layer === sinkLayer;
+        // Odd-count intermediate layers get a half-step offset so no node lands at y=0
+        const offset = (!isEndpoint && ids.length % 2 === 1) ? nodeYSpacing / 2 : 0;
+        ids.forEach((id, i) => {
+          positions[id] = { x, y: (i - (ids.length - 1) / 2) * nodeYSpacing + offset };
+        });
+      });
+      bfsNodePositionsRef.current = positions;
+    }
 
     try {
       // More thorough cleanup of previous instance
@@ -448,7 +507,6 @@ export const useCytoscape = ({
               minNodeSpacing: isVeryLarge ? 10 : 30
             };
           case 'klay':
-          default:
             return {
               ...baseConfig,
               name: 'klay',
@@ -460,6 +518,18 @@ export const useCytoscape = ({
                 edgeRouting: 'POLYLINE'
               }
             };
+          case 'bfs-tiered':
+          default: {
+            const pos = bfsNodePositionsRef.current;
+            return {
+              name: 'preset',
+              positions: (node) => pos[node.id()] ?? { x: 0, y: 0 },
+              fit: true,
+              padding: isVeryLarge ? 10 : 30,
+              animate: false,
+              ready: () => { if (cyRef.current) { cyRef.current.resize(); cyRef.current.center(); } }
+            };
+          }
         }
       };
 
@@ -612,35 +682,31 @@ export const useCytoscape = ({
         navigator.clipboard.writeText(text).then(() => {
           onTooltip({ text: `Copied: ${text}`, position: { x: position.x, y: position.y } });
           setTimeout(() => onTooltip({ text: '', position: null }), 1500);
-        });
+        }).catch(() => {});
       };
-      cy.on('cxttap', 'node', (event) => {
-        copyToClipboard(event.target.id(), event.renderedPosition);
-      });
       cy.on('cxttap', 'edge', (event) => {
         const d = event.target.data();
         copyToClipboard(d.tokenOwner || `${d.source}→${d.target}`, event.renderedPosition);
       });
 
-      // Node click: remove node and its chain from selection
-      if (onNodeRemoveRef.current) {
-        cy.on('click', 'node', (event) => {
-          const node = event.target;
-          if (node.data('isSource') || node.data('isSink') || node.data('isSameSourceSink')) return;
-          onNodeRemoveRef.current?.(node.id());
+      // Node click: open context menu
+      cy.on('click', 'node', (event) => {
+        const node = event.target;
+        const pos = event.renderedPosition;
+        onNodeMenu?.({
+          id: node.id(),
+          position: { x: pos.x, y: pos.y },
+          isIntermediate: !node.data('isSource') && !node.data('isSink') && !node.data('isSameSourceSink'),
         });
+      });
 
-        // Visual cue: pointer cursor on removable intermediate nodes
-        cy.on('mouseover', 'node', (event) => {
-          const node = event.target;
-          if (!node.data('isSource') && !node.data('isSink') && !node.data('isSameSourceSink')) {
-            containerRef.current.style.cursor = 'pointer';
-          }
-        });
-        cy.on('mouseout', 'node', () => {
-          containerRef.current.style.cursor = '';
-        });
-      }
+      // Visual cue: pointer cursor on all nodes
+      cy.on('mouseover', 'node', () => {
+        if (containerRef.current) containerRef.current.style.cursor = 'pointer';
+      });
+      cy.on('mouseout', 'node', () => {
+        if (containerRef.current) containerRef.current.style.cursor = '';
+      });
 
       const renderTime = performance.now() - startTime;
       updateStats({ renderTime: Math.round(renderTime) });
@@ -717,7 +783,8 @@ export const useCytoscape = ({
       cy.nodes().forEach((node) => {
         const id = node.id();
         const profile = nodeProfiles[id];
-        const shortAddr = `${id.slice(0, 6)}...${id.slice(-4)}`;
+        const displayId = checksumAddr(id);
+        const shortAddr = `${displayId.slice(0, 6)}...${displayId.slice(-4)}`;
         node.data('label', (showNames && profile?.name) ? profile.name : shortAddr);
       });
     });
@@ -930,7 +997,6 @@ export const useCytoscape = ({
             minNodeSpacing: isVeryLarge ? 10 : 30
           };
         case 'klay':
-        default:
           return {
             ...baseConfig,
             name: 'klay',
@@ -942,6 +1008,19 @@ export const useCytoscape = ({
               edgeRouting: 'POLYLINE'
             }
           };
+        case 'bfs-tiered':
+        default: {
+          const pos = bfsNodePositionsRef.current;
+          return {
+            name: 'preset',
+            positions: (node) => pos[node.id()] ?? { x: 0, y: 0 },
+            fit: true,
+            padding: isVeryLarge ? 10 : 30,
+            animate: !isVeryLarge && !config.rendering.fastMode,
+            animationDuration: isVeryLarge ? 0 : 300,
+            ready: () => { if (cyRef.current) { cyRef.current.resize(); cyRef.current.center(); } }
+          };
+        }
       }
     };
 

--- a/src/lib/utils.jsx
+++ b/src/lib/utils.jsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { checksumAddress } from 'viem';
 
 /**
  * Combines multiple class names using clsx and tailwind-merge
@@ -7,6 +8,10 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+export const checksumAddr = (addr) => {
+  try { return checksumAddress(addr); } catch { return addr; }
+};
 
 /**
  * Packs coordinates into bytes as required by the operateFlowMatrix function


### PR DESCRIPTION
## Summary

- **EIP-55 checksums**: All displayed addresses now use mixed-case EIP-55 checksum form. Internal comparisons/lookups remain lowercase. Added `checksumAddr` helper (viem `checksumAddress`) and a reusable `CopyableAddress` component.
- **Clickable addresses**: Addresses in transaction table, path stats, flow matrix params, and graph node context menu are clickable to copy full checksummed address to clipboard.
- **BFS-tiered graph layout**: New default layout places source leftmost, sink rightmost, and intermediate nodes in strict hop-depth columns. Odd-count intermediate columns are offset by half node spacing to prevent nodes sitting on the direct source→sink center edge.
- **Ctrl/Cmd+Enter shortcut**: Triggers Find Path; keyboard hint (⌘↵) shown on button. Guarded against firing when simulation editor is open.
- **Node left-click context menu**: Replaces right-click node removal with a menu offering Copy Address and Remove from Graph. Right-click on nodes removed.
- **Undo node removal**: ↩ Undo removal button appears after any node is removed from the graph. Stack clears on new path search.
- **InfoTip fixes**: Tooltip clipping fixed by switching to `position: fixed` with `getBoundingClientRect`; icon vertical alignment fixed with `align-middle`.
- **Persisted layout selection**: Selected graph layout saved to localStorage, survives page refresh.

## Test plan

- [ ] Addresses shown in mixed-case EIP-55 form across all panels (not lowercased)
- [ ] Clicking an address in any table copies it to clipboard
- [ ] BFS Tiered layout shows source left, sink right, intermediates in tier columns
- [ ] No intermediate node sits on the direct center edge between source and sink
- [ ] Ctrl+Enter (Mac: Cmd+Enter) triggers Find Path
- [ ] Left-clicking a graph node opens context menu with Copy Address and Remove from Graph
- [ ] Remove from Graph removes node's routes; ↩ Undo removal restores them
- [ ] Selecting Klay layout, refreshing page → Klay persists (not reverting to BFS Tiered)