### PR TITLE
feat: time-travel mode — pin pathfinding to a past block + execute on an Anvil fork

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,14 @@
 # VITE_API_ENDPOINT=https://rpc.aboutcircles.com/
 # VITE_STAGING_ENDPOINT=https://rpc.staging.aboutcircles.com/
 
-# Circles test environment base URL, used by "time-travel" mode (Block Number field) and
-# the "Execute on fork" button. When a block is selected, the app creates a session here
-# and routes pathfinding + fork execution through it, pinned to that block.
+# Circles test environment base URL. This ENABLES the opt-in "time-travel" feature: the
+# Block Number field + "Execute on fork" button. When unset (e.g. the public GitHub Pages
+# build), the feature is hidden entirely and the app behaves exactly as before.
+#
+# When set, selecting a block creates a test-env session and routes pathfinding + fork
+# execution through it, pinned to that block.
 #
 # NOTE: the test environment enforces a GLOBAL 10-session cap and (by default) allows any
-# CORS origin. Keep this app internal-only, or point it at a dedicated test-env instance,
-# so public traffic cannot exhaust the session pool.
-VITE_TEST_ENV_URL=https://rpc.staging.aboutcircles.com/test-env
+# CORS origin. Only set this for internal/local builds or a dedicated test-env instance —
+# leaving it unset on a public deploy prevents anonymous visitors from exhausting the pool.
+# VITE_TEST_ENV_URL=https://rpc.staging.aboutcircles.com/test-env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env.local and adjust as needed. All vars are optional; defaults target
+# the public Circles endpoints.
+
+# Default (head) RPC endpoints. Overriding is rarely needed.
+# VITE_API_ENDPOINT=https://rpc.aboutcircles.com/
+# VITE_STAGING_ENDPOINT=https://rpc.staging.aboutcircles.com/
+
+# Circles test environment base URL, used by "time-travel" mode (Block Number field) and
+# the "Execute on fork" button. When a block is selected, the app creates a session here
+# and routes pathfinding + fork execution through it, pinned to that block.
+#
+# NOTE: the test environment enforces a GLOBAL 10-session cap and (by default) allows any
+# CORS origin. Keep this app internal-only, or point it at a dedicated test-env instance,
+# so public traffic cannot exhaust the session pool.
+VITE_TEST_ENV_URL=https://rpc.staging.aboutcircles.com/test-env

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -524,7 +524,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
                   {copied.calldata ? <Check size={16} /> : <Copy size={16} />}
                   {copied.calldata ? "Copied!" : "Calldata"}
                 </Button>
-                {blockNumber && (
+                {blockNumber && showProcessed && (
                   <Button
                     onClick={handleExecuteOnFork}
                     disabled={isForkRunning || !flowMatrix}
@@ -619,10 +619,17 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
             <div className="font-medium">Execute on fork (block {blockNumber})</div>
             {forkError && <div>Error: {forkError}</div>}
             {forkResult?.success && (
-              <div>✔ Would succeed on-chain{forkResult.gasUsed ? ` — gas ${forkResult.gasUsed}` : ''}.</div>
+              <div>✔ Would succeed on-chain{forkResult.gasUsed ? ` — est. gas ${forkResult.gasUsed}` : ''}.</div>
             )}
             {forkResult && !forkResult.success && (
-              <div>✖ Reverts: {forkResult.revertReason}</div>
+              <>
+                <div>✖ Reverts: {forkResult.revertReason}</div>
+                <div className="mt-1 text-xs text-red-700">
+                  Note: this runs the bare operateFlowMatrix. Paths that use wrapped balances
+                  (Include Wrapped Tokens) revert here without the unwrap steps — use “Simulate”
+                  for those, or turn off wrapped tokens to validate the direct transfer.
+                </div>
+              </>
             )}
           </div>
         )}

--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -8,7 +8,7 @@ import { encodeFunctionData } from "viem";
 import { useAccount, useConnect, useDisconnect, useSwitchChain, useWriteContract, useWaitForTransactionReceipt, usePublicClient } from "wagmi";
 import { gnosis } from "wagmi/chains";
 import { HUB_ADDRESS } from "@/config/wagmi";
-import { buildSafeFlowMatrixSimulationTx } from "@/services/circlesApi";
+import { buildSafeFlowMatrixSimulationTx, executeFlowMatrixOnFork } from "@/services/circlesApi";
 import CopyableAddress from "@/components/ui/copyable-address";
 
 // Just the operateFlowMatrix function ABI
@@ -131,7 +131,7 @@ const resolveSimulationSigner = async ({ publicClient, safeAddress, connectedAdd
   };
 };
 
-const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcessed, isFiltered, view = 'all' }) => {
+const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcessed, isFiltered, view = 'all', blockNumber = '' }) => {
   const showParamsSection = view !== 'simulation';
   const showSimulationSection = view !== 'params';
   const [flowMatrix, setFlowMatrix] = useState(null);
@@ -143,6 +143,9 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
   const [simulationError, setSimulationError] = useState(null);
   const [simulationErrorLog, setSimulationErrorLog] = useState('');
   const [simulationResult, setSimulationResult] = useState(null);
+  const [forkResult, setForkResult] = useState(null);
+  const [isForkRunning, setIsForkRunning] = useState(false);
+  const [forkError, setForkError] = useState(null);
 
   const { address, isConnected, chain } = useAccount();
   const publicClient = usePublicClient();
@@ -398,6 +401,41 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
     }
   };
 
+  // Execute the operateFlowMatrix call on the session's Anvil fork of the pinned block and
+  // report success/revert. No wallet needed — this is an eth_call from the flow source on
+  // a throwaway fork. Only available in time-travel mode (a block is selected).
+  const handleExecuteOnFork = async () => {
+    setForkError(null);
+    setForkResult(null);
+
+    let calldata = null;
+    try {
+      calldata = getCalldata();
+    } catch (err) {
+      setForkError(err?.message || 'Could not build calldata');
+      return;
+    }
+    if (!calldata || !sender) {
+      setForkError('No calldata or source available.');
+      return;
+    }
+
+    setIsForkRunning(true);
+    try {
+      const result = await executeFlowMatrixOnFork({
+        blockNumber,
+        source: sender,
+        hubAddress: HUB_ADDRESS,
+        calldata,
+      });
+      setForkResult(result);
+    } catch (err) {
+      setForkError(err?.message || 'Fork execution failed');
+    } finally {
+      setIsForkRunning(false);
+    }
+  };
+
   if (error && showParamsSection) {
     return (
       <Card className="mt-4">
@@ -486,6 +524,16 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
                   {copied.calldata ? <Check size={16} /> : <Copy size={16} />}
                   {copied.calldata ? "Copied!" : "Calldata"}
                 </Button>
+                {blockNumber && (
+                  <Button
+                    onClick={handleExecuteOnFork}
+                    disabled={isForkRunning || !flowMatrix}
+                    variant="outline"
+                    className="flex items-center gap-1 border-purple-300 text-purple-700 hover:bg-purple-50"
+                  >
+                    {isForkRunning ? 'Running on fork…' : 'Execute on fork'}
+                  </Button>
+                )}
               </>
             )}
             {!isConnected ? (
@@ -557,6 +605,25 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
             Transaction submitted: {hash.slice(0, 10)}...{hash.slice(-8)}
             {isConfirming && " - Confirming..."}
             {isConfirmed && " - Confirmed!"}
+          </div>
+        )}
+
+        {showParamsSection && (forkResult || forkError) && (
+          <div
+            className={`mb-2 p-3 rounded text-sm border ${
+              forkResult?.success
+                ? 'bg-green-50 border-green-200 text-green-900'
+                : 'bg-red-50 border-red-200 text-red-900'
+            }`}
+          >
+            <div className="font-medium">Execute on fork (block {blockNumber})</div>
+            {forkError && <div>Error: {forkError}</div>}
+            {forkResult?.success && (
+              <div>✔ Would succeed on-chain{forkResult.gasUsed ? ` — gas ${forkResult.gasUsed}` : ''}.</div>
+            )}
+            {forkResult && !forkResult.success && (
+              <div>✖ Reverts: {forkResult.revertReason}</div>
+            )}
           </div>
         )}
 
@@ -761,6 +828,7 @@ FlowMatrixParams.propTypes = {
   showProcessed: PropTypes.bool,
   isFiltered: PropTypes.bool,
   view: PropTypes.oneOf(['all', 'params', 'simulation']),
+  blockNumber: PropTypes.string,
 };
 
 export default FlowMatrixParams;

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -1272,6 +1272,7 @@ const FlowVisualization = () => {
                         showProcessed={showProcessed}
                         isFiltered={!!filteredPathData}
                         view="params"
+                        blockNumber={formData.BlockNumber}
                       />
                     </TabsContent>
 

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -8,6 +8,7 @@ import TokenInput from '@/components/ui/token-input';
 import ToggleSwitch from '@/components/ui/toggle-switch';
 import InfoTip from '@/components/ui/info-tip';
 import { parseAddressList } from '@/services/circlesApi';
+import { isTestEnvConfigured } from '@/services/testEnv';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
 const BALANCES_GRID_COLUMNS = ['holder', 'token', 'amount', 'isWrapped', 'isStatic'];
@@ -400,19 +401,21 @@ const PathFinderForm = ({
             type="number"
           />
         </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">
-            Block Number (time-travel)
-            <InfoTip text="Pin the pathfinder and graph to a past block via a test-env session. Leave empty for latest. Requires VITE_TEST_ENV_URL (defaults to the staging test environment)." />
-          </label>
-          <Input
-            name="blockNumber"
-            value={formData.BlockNumber}
-            onChange={handleInputChange}
-            placeholder="latest"
-            type="number"
-          />
-        </div>
+        {isTestEnvConfigured() && (
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Block Number (time-travel)
+              <InfoTip text="Pin the pathfinder and graph to a past block via a test-env session. Leave empty for latest." />
+            </label>
+            <Input
+              name="blockNumber"
+              value={formData.BlockNumber}
+              onChange={handleInputChange}
+              placeholder="latest"
+              type="number"
+            />
+          </div>
+        )}
         <div className="space-y-2">
           <label className="block text-sm font-medium mb-1">
             Simulations

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -400,6 +400,19 @@ const PathFinderForm = ({
             type="number"
           />
         </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Block Number (time-travel)
+            <InfoTip text="Pin the pathfinder and graph to a past block via a test-env session. Leave empty for latest. Requires VITE_TEST_ENV_URL (defaults to the staging test environment)." />
+          </label>
+          <Input
+            name="blockNumber"
+            value={formData.BlockNumber}
+            onChange={handleInputChange}
+            placeholder="latest"
+            type="number"
+          />
+        </div>
         <div className="space-y-2">
           <label className="block text-sm font-medium mb-1">
             Simulations
@@ -632,6 +645,7 @@ PathFinderForm.propTypes = {
     WithWrap: PropTypes.bool.isRequired,
     UseStaging: PropTypes.bool.isRequired,
     MaxTransfers: PropTypes.string,
+    BlockNumber: PropTypes.string,
     IsFromTokensExcluded: PropTypes.bool.isRequired,
     IsToTokensExcluded: PropTypes.bool.isRequired,
     QuantizedMode: PropTypes.bool.isRequired,

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -42,6 +42,7 @@ const DEFAULTS = {
   SimulatedBalances: '[]',
   SimulatedTrusts: '[]',
   SimulatedConsentedAvatars: '',
+  BlockNumber: '',
 };
 
 const isAddress = (value) => typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value.trim());

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -99,6 +99,7 @@ export const useFormData = () => {
         name === 'fromTokens' ? 'FromTokens' :
         name === 'toTokens' ? 'ToTokens' :
         name === 'maxTransfers' ? 'MaxTransfers' :
+        name === 'blockNumber' ? 'BlockNumber' :
         name;
 
       // Clear token filters when addresses change (stale filters cause empty results)

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -9,7 +9,7 @@ import {
 } from "@aboutcircles/sdk-pathfinder";
 import { encodeFunctionData, concatHex } from 'viem';
 import cacheService from './cacheService';
-import { getTestEnvSession, anvilRpc, decodeRevert } from './testEnv';
+import { getTestEnvSession, anvilRpc, decodeRevert, isTestEnvConfigured } from './testEnv';
 
 export const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT || 'https://rpc.aboutcircles.com/';
 export const STAGING_ENDPOINT = import.meta.env.VITE_STAGING_ENDPOINT || 'https://rpc.staging.aboutcircles.com/';
@@ -123,7 +123,7 @@ export const findPath = async (formData, sdkRpc) => {
   // proxy that injects X-Max-Block-Number, so the path resolves against that past block.
   const blockNumber = parseBlockNumber(formData.BlockNumber);
   let rpc;
-  if (blockNumber) {
+  if (blockNumber && isTestEnvConfigured()) {
     const session = await getTestEnvSession(blockNumber);
     rpc = new CirclesRpc(session.rpcUrl);
   } else if (formData.UseStaging) {
@@ -225,7 +225,13 @@ export const executeFlowMatrixOnFork = async ({ blockNumber, source, hubAddress,
   try {
     await anvilRpc(session.anvilUrl, 'eth_call', [tx, 'latest']);
   } catch (err) {
-    return { success: false, revertReason: decodeRevert(err) };
+    // Only a genuine contract revert is a "would-fail-on-chain" signal. Infra failures
+    // (network, HTTP, timeout, expired session) are rethrown so the UI shows "couldn't
+    // run" rather than a misleading revert that looks like a pathfinder bug.
+    if (err?.kind === 'revert') {
+      return { success: false, revertReason: decodeRevert(err) };
+    }
+    throw err;
   }
 
   // Succeeded — best-effort gas estimate for display (never fail the result on this).

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -9,9 +9,17 @@ import {
 } from "@aboutcircles/sdk-pathfinder";
 import { encodeFunctionData, concatHex } from 'viem';
 import cacheService from './cacheService';
+import { getTestEnvSession, anvilRpc, decodeRevert } from './testEnv';
 
-export const API_ENDPOINT = 'https://rpc.aboutcircles.com/';
-export const STAGING_ENDPOINT = 'https://rpc.staging.aboutcircles.com/';
+export const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT || 'https://rpc.aboutcircles.com/';
+export const STAGING_ENDPOINT = import.meta.env.VITE_STAGING_ENDPOINT || 'https://rpc.staging.aboutcircles.com/';
+
+// Positive integer block number from form input, or null (→ live/head).
+export const parseBlockNumber = (value) => {
+  if (value === undefined || value === null || String(value).trim() === '') return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : null;
+};
 
 const fetchTokenBalancesForAddress = async (address) => {
   const res = await fetch(API_ENDPOINT, {
@@ -110,9 +118,19 @@ export const ethToWei = (crcAmount) => {
 };
 
 export const findPath = async (formData, sdkRpc) => {
-  // If staging endpoint requested, create a temporary SDK client for it
-  const endpoint = formData.UseStaging ? STAGING_ENDPOINT : API_ENDPOINT;
-  const rpc = formData.UseStaging ? new CirclesRpc(STAGING_ENDPOINT) : sdkRpc;
+  // Endpoint precedence: block-pinned test-env session > staging toggle > default (head).
+  // A pinned session routes RPC (and thus circlesV2_findPath → pathfinder) through the
+  // proxy that injects X-Max-Block-Number, so the path resolves against that past block.
+  const blockNumber = parseBlockNumber(formData.BlockNumber);
+  let rpc;
+  if (blockNumber) {
+    const session = await getTestEnvSession(blockNumber);
+    rpc = new CirclesRpc(session.rpcUrl);
+  } else if (formData.UseStaging) {
+    rpc = new CirclesRpc(STAGING_ENDPOINT);
+  } else {
+    rpc = sdkRpc;
+  }
   try {
     // Include and exclude can coexist when quick-filter sends both
     const fromTokensArray = formData.IsFromTokensExcluded
@@ -187,6 +205,38 @@ export const findPath = async (formData, sdkRpc) => {
     console.error('SDK findPath error:', err);
     throw err;
   }
+};
+
+/**
+ * Execute a pathfinder-computed operateFlowMatrix call on the session's Anvil fork of the
+ * pinned block and report whether it reverts. Uses eth_call from the flow source (no
+ * signature needed on a fork); the fork state matches the block the path was computed at,
+ * so a revert means the pathfinder produced a path that would fail on-chain.
+ * Returns { success, gasUsed?, revertReason? }.
+ */
+export const executeFlowMatrixOnFork = async ({ blockNumber, source, hubAddress, calldata }) => {
+  const block = parseBlockNumber(blockNumber);
+  if (!block) throw new Error('A positive block number is required to execute on the fork.');
+  if (!source || !hubAddress || !calldata) throw new Error('Missing source, hub address, or calldata.');
+
+  const session = await getTestEnvSession(block);
+  const tx = { from: source, to: hubAddress, data: calldata };
+
+  try {
+    await anvilRpc(session.anvilUrl, 'eth_call', [tx, 'latest']);
+  } catch (err) {
+    return { success: false, revertReason: decodeRevert(err) };
+  }
+
+  // Succeeded — best-effort gas estimate for display (never fail the result on this).
+  let gasUsed = null;
+  try {
+    const gasHex = await anvilRpc(session.anvilUrl, 'eth_estimateGas', [tx]);
+    gasUsed = gasHex ? BigInt(gasHex).toString() : null;
+  } catch {
+    // gas is informational only
+  }
+  return { success: true, gasUsed };
 };
 
 export const processPath = async (rawPath, sourceAddress) => {

--- a/src/services/testEnv.js
+++ b/src/services/testEnv.js
@@ -8,9 +8,11 @@
 // Configure with VITE_TEST_ENV_URL (defaults to staging). CORS defaults to "*" on the
 // test-env, but a locked-down deployment must allow this app's origin.
 
-export const TEST_ENV_URL = (
-  import.meta.env.VITE_TEST_ENV_URL || 'https://rpc.staging.aboutcircles.com/test-env'
-).replace(/\/+$/, '');
+// No default on purpose: time-travel is OFF unless VITE_TEST_ENV_URL is explicitly set.
+// This keeps the feature disabled on the public GitHub Pages build (which sets no env),
+// so anonymous visitors can't create test-env sessions and exhaust the global session cap.
+// Internal/local builds opt in via .env.local (see .env.example).
+export const TEST_ENV_URL = (import.meta.env.VITE_TEST_ENV_URL || '').replace(/\/+$/, '');
 
 export const isTestEnvConfigured = () => Boolean(TEST_ENV_URL);
 
@@ -72,24 +74,66 @@ export const getTestEnvSession = (blockNumber) => {
   return entry;
 };
 
+// A genuine EVM revert (vs an infra/transport error) carries revert bytes in `data`, a
+// "revert" message, or the standard revert code 3. Everything else — HTTP 5xx, timeouts,
+// -32603/-32000 internal errors, expired sessions, network failures — is infra and must
+// NOT be presented to the user as a contract revert.
+const isRevertError = (error) => {
+  const hasRevertData =
+    typeof error?.data === 'string' && error.data.startsWith('0x') && error.data.length > 2;
+  const msg = (error?.message || '').toLowerCase();
+  return hasRevertData || msg.includes('revert') || error?.code === 3;
+};
+
 /**
- * POST a single JSON-RPC call to a session's Anvil fork. Throws on a JSON-RPC error,
- * attaching `.data` (revert bytes, if any) and `.code` for the caller to decode.
+ * POST a single JSON-RPC call to a session's Anvil fork. Throws on any failure, tagging the
+ * error `.kind`: 'revert' for a genuine contract revert (carries `.data`/`.code`), else
+ * 'infra' (network / HTTP / non-JSON / timeout / missing result) so callers never mistake
+ * an infra failure for an on-chain revert.
  */
 export const anvilRpc = async (anvilUrl, method, params) => {
-  const res = await fetch(anvilUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
-  });
-  const data = await res.json().catch(() => ({}));
+  let res;
+  try {
+    res = await fetch(anvilUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    });
+  } catch (netErr) {
+    const e = new Error(`could not reach the fork: ${netErr?.message || netErr}`);
+    e.kind = 'infra';
+    throw e;
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    const e = new Error(`fork proxy returned HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ''}`);
+    e.kind = 'infra';
+    throw e;
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    const e = new Error('fork returned a non-JSON response');
+    e.kind = 'infra';
+    throw e;
+  }
+
   if (data?.error) {
     const err = new Error(data.error.message || 'anvil JSON-RPC error');
     err.data = data.error.data;
     err.code = data.error.code;
+    err.kind = isRevertError(data.error) ? 'revert' : 'infra';
     throw err;
   }
-  return data?.result;
+  if (data.result === undefined) {
+    const e = new Error('fork returned no result');
+    e.kind = 'infra';
+    throw e;
+  }
+  return data.result;
 };
 
 // Known Circles/OZ error selectors → human labels, so a fork revert reads clearly.

--- a/src/services/testEnv.js
+++ b/src/services/testEnv.js
@@ -1,0 +1,119 @@
+// Thin client for the Circles test environment session API.
+//
+// A session pins a block: the test-env proxies inject `X-Max-Block-Number` server-side,
+// so pointing the SDK's CirclesRpc at the session's `/rpc` proxy makes pathfinding (and
+// the RPC reads it drives) resolve against that block. The `/anvil` proxy is a real
+// Gnosis fork at the same block for on-chain execution.
+//
+// Configure with VITE_TEST_ENV_URL (defaults to staging). CORS defaults to "*" on the
+// test-env, but a locked-down deployment must allow this app's origin.
+
+export const TEST_ENV_URL = (
+  import.meta.env.VITE_TEST_ENV_URL || 'https://rpc.staging.aboutcircles.com/test-env'
+).replace(/\/+$/, '');
+
+export const isTestEnvConfigured = () => Boolean(TEST_ENV_URL);
+
+const sessionBase = (sessionId) => `${TEST_ENV_URL}/api/v1/session/${sessionId}`;
+
+// One session per block number — the test-env enforces a global 10-session cap, so we
+// must not spin up a fresh session per request. Cached by the promise so concurrent
+// callers (findPath + execute-on-fork) share the same in-flight creation.
+const sessionCache = new Map();
+
+const createSession = async (blockNumber) => {
+  const res = await fetch(`${TEST_ENV_URL}/api/v1/session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      blockNumber: Number(blockNumber),
+      features: ['rpc', 'anvil'],
+      ttl: '30m',
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`test-env session create failed (${res.status})${text ? `: ${text}` : ''}`);
+  }
+
+  const data = await res.json();
+  const sessionId = data?.sessionId || data?.SessionId;
+  if (!sessionId) {
+    throw new Error('test-env session response missing sessionId');
+  }
+
+  const base = sessionBase(sessionId);
+  return {
+    sessionId,
+    blockNumber: Number(blockNumber),
+    rpcUrl: `${base}/rpc`,
+    pathfinderUrl: `${base}/pathfinder`,
+    anvilUrl: `${base}/anvil`,
+    accounts: data?.anvil?.accounts || [],
+  };
+};
+
+/**
+ * Get (or lazily create) a cached test-env session pinned to `blockNumber`.
+ * Returns { sessionId, blockNumber, rpcUrl, pathfinderUrl, anvilUrl, accounts }.
+ */
+export const getTestEnvSession = (blockNumber) => {
+  const key = String(blockNumber);
+  let entry = sessionCache.get(key);
+  if (!entry) {
+    entry = createSession(blockNumber);
+    // Drop failed creations so a later attempt can retry instead of caching the rejection.
+    entry.catch(() => {
+      if (sessionCache.get(key) === entry) sessionCache.delete(key);
+    });
+    sessionCache.set(key, entry);
+  }
+  return entry;
+};
+
+/**
+ * POST a single JSON-RPC call to a session's Anvil fork. Throws on a JSON-RPC error,
+ * attaching `.data` (revert bytes, if any) and `.code` for the caller to decode.
+ */
+export const anvilRpc = async (anvilUrl, method, params) => {
+  const res = await fetch(anvilUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (data?.error) {
+    const err = new Error(data.error.message || 'anvil JSON-RPC error');
+    err.data = data.error.data;
+    err.code = data.error.code;
+    throw err;
+  }
+  return data?.result;
+};
+
+// Known Circles/OZ error selectors → human labels, so a fork revert reads clearly.
+// (Mirrors the plugin's AnvilExecutionHelper.KnownErrorSelectors.)
+const KNOWN_ERROR_SELECTORS = {
+  '0x5e418dba': 'CirclesHubFlowEdgeIsNotPermitted',
+  '0xc14c0700': 'CirclesAvatarMustBeRegistered',
+  '0x03dee4c5': 'ERC1155InsufficientBalance',
+  '0x57f447ce': 'ERC1155InvalidReceiver',
+  '0x659c8c43': 'AmountExceedsCollateralLimit',
+};
+
+/**
+ * Decode a revert into a short human label. Prefers a known selector match on the
+ * revert bytes, falls back to the raw JSON-RPC message.
+ */
+export const decodeRevert = (err) => {
+  const raw = typeof err?.data === 'string' ? err.data : null;
+  if (raw && raw.length >= 10) {
+    const selector = raw.slice(0, 10).toLowerCase();
+    if (KNOWN_ERROR_SELECTORS[selector]) {
+      return `${KNOWN_ERROR_SELECTORS[selector]} (${selector})`;
+    }
+    return `reverted (${selector})`;
+  }
+  return err?.message || 'reverted';
+};


### PR DESCRIPTION
## Summary
Adds a **Block Number** field and an **Execute on fork** button so the visualizer can reproduce and validate paths against *past* on-chain state, using the Circles test environment. Internal-use tool (see session-cap note below).

## How it works
- **Time-travel**: when a block is entered, the app creates a test-env session at that block and points the RPC/pathfinder clients at the session proxy URLs. The proxy injects `X-Max-Block-Number` server-side, so pathfinding (and the RPC reads it drives) resolve against that block — the SDK stays untouched (only its base URL changes). Empty block = latest, as today.
- **Execute on fork**: runs the computed `operateFlowMatrix` on the session's Anvil fork of the same block via `eth_call` from the flow source (no wallet/signature needed), and reports ✔ would-succeed (+ gas) or ✖ the decoded revert reason. This is the visual counterpart of the plugin's Anvil differential check.

## Changes
- `src/services/testEnv.js` (new): session client cached per block (respects the test-env's **global 10-session cap**), Anvil JSON-RPC helper, revert-selector decoding.
- `src/services/circlesApi.js`: `parseBlockNumber`; `findPath` routes through the pinned session; `executeFlowMatrixOnFork(...)`. Endpoints now overridable via `VITE_*`.
- `src/hooks/useFormData.js`, `src/components/PathFinderForm.jsx`: Block Number field.
- `src/components/FlowMatrixParams.jsx`, `FlowVisualization.jsx`: Execute-on-fork button + result panel.
- `.env.example`: `VITE_TEST_ENV_URL` (defaults to staging).

No new dependencies — execute-on-fork reuses the existing `createFlowMatrix` + Hub ABI.

## Notes / caveats
- The test environment enforces a **global 10-session cap** and defaults CORS to `*`. Keep this app **internal-only** (or point it at a dedicated test-env) so public traffic can't exhaust the pool.
- Execute-on-fork needs the **resolved** (wrapper-free) path to produce valid calldata — use "Resolve Wrappers" for executable output.

## Test plan
- [x] `vite build` succeeds (4617 modules)
- [ ] Live smoke: enter a past block, run Find Path (pins to block), open Parameters tab → Execute on fork → observe success/gas or revert reason
- [ ] Verify a known-reverting path shows the decoded revert (e.g. a raw/unresolved path)
- Note: repo-wide `npm run lint` is currently broken by a pre-existing eslint/`globals` version incompat (unrelated to this PR).