### PR TITLE
fix(fork): run the full unwrap bundle so wrapped-balance paths don't revert

### DIFF
--- a/src/components/FlowMatrixParams.jsx
+++ b/src/components/FlowMatrixParams.jsx
@@ -408,15 +408,11 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
     setForkError(null);
     setForkResult(null);
 
-    let calldata = null;
-    try {
-      calldata = getCalldata();
-    } catch (err) {
-      setForkError(err?.message || 'Could not build calldata');
-      return;
-    }
-    if (!calldata || !sender) {
-      setForkError('No calldata or source available.');
+    // Use the raw path (with wrapper addresses) — buildSafeFlowMatrixSimulationTx resolves
+    // wrappers and injects the unwrap/re-wrap legs itself, same as the Simulate button.
+    const forkPathData = rawPathData || pathData;
+    if (!forkPathData || !sender || !receiver) {
+      setForkError('No path, source, or sink available.');
       return;
     }
 
@@ -424,9 +420,10 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
     try {
       const result = await executeFlowMatrixOnFork({
         blockNumber,
+        pathData: forkPathData,
         source: sender,
+        receiver,
         hubAddress: HUB_ADDRESS,
-        calldata,
       });
       setForkResult(result);
     } catch (err) {
@@ -524,7 +521,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
                   {copied.calldata ? <Check size={16} /> : <Copy size={16} />}
                   {copied.calldata ? "Copied!" : "Calldata"}
                 </Button>
-                {blockNumber && showProcessed && (
+                {blockNumber && (
                   <Button
                     onClick={handleExecuteOnFork}
                     disabled={isForkRunning || !flowMatrix}
@@ -622,14 +619,7 @@ const FlowMatrixParams = ({ pathData, rawPathData, sender, receiver, showProcess
               <div>✔ Would succeed on-chain{forkResult.gasUsed ? ` — est. gas ${forkResult.gasUsed}` : ''}.</div>
             )}
             {forkResult && !forkResult.success && (
-              <>
-                <div>✖ Reverts: {forkResult.revertReason}</div>
-                <div className="mt-1 text-xs text-red-700">
-                  Note: this runs the bare operateFlowMatrix. Paths that use wrapped balances
-                  (Include Wrapped Tokens) revert here without the unwrap steps — use “Simulate”
-                  for those, or turn off wrapped tokens to validate the direct transfer.
-                </div>
-              </>
+              <div>✖ Reverts: {forkResult.revertReason}</div>
             )}
           </div>
         )}

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -7,7 +7,7 @@ import {
   getWrappedTokensFromPath,
   replaceWrappedTokensWithAvatars,
 } from "@aboutcircles/sdk-pathfinder";
-import { encodeFunctionData, concatHex } from 'viem';
+import { encodeFunctionData, concatHex, decodeFunctionResult } from 'viem';
 import cacheService from './cacheService';
 import { getTestEnvSession, anvilRpc, decodeRevert, isTestEnvConfigured } from './testEnv';
 
@@ -207,27 +207,69 @@ export const findPath = async (formData, sdkRpc) => {
   }
 };
 
+const SAFE_GET_OWNERS_ABI = [{
+  type: 'function',
+  name: 'getOwners',
+  stateMutability: 'view',
+  inputs: [],
+  outputs: [{ name: '', type: 'address[]' }],
+}];
+
+// Read the Safe owners of `safe` from the fork so we can pick a signer for the Safe
+// execTransaction simulation without a connected wallet (eth_call needs no real signature).
+const readSafeOwnersOnFork = async (anvilUrl, safe) => {
+  const data = encodeFunctionData({ abi: SAFE_GET_OWNERS_ABI, functionName: 'getOwners' });
+  const resultHex = await anvilRpc(anvilUrl, 'eth_call', [{ to: safe, data }, 'latest']);
+  return decodeFunctionResult({ abi: SAFE_GET_OWNERS_ABI, functionName: 'getOwners', data: resultHex });
+};
+
 /**
- * Execute a pathfinder-computed operateFlowMatrix call on the session's Anvil fork of the
- * pinned block and report whether it reverts. Uses eth_call from the flow source (no
- * signature needed on a fork); the fork state matches the block the path was computed at,
- * so a revert means the pathfinder produced a path that would fail on-chain.
- * Returns { success, gasUsed?, revertReason? }.
+ * Execute a pathfinder-computed transfer on the session's Anvil fork of the pinned block and
+ * report whether it reverts. Builds the SAME full bundle as the "Simulate" button
+ * (self-approval → wrapper.unwrap() → operateFlowMatrix → re-wrap) via
+ * buildSafeFlowMatrixSimulationTx — so paths that rely on wrapped (ERC-20) balances work,
+ * not just bare ERC-1155 transfers. Wrapper/token data is resolved against the block-pinned
+ * session RPC so it matches the fork. eth_call from a Safe owner (no signature needed on a
+ * fork); a revert means the path would fail on-chain. Returns { success, gasUsed?, revertReason? }.
  */
-export const executeFlowMatrixOnFork = async ({ blockNumber, source, hubAddress, calldata }) => {
+export const executeFlowMatrixOnFork = async ({ blockNumber, pathData, source, receiver, hubAddress }) => {
   const block = parseBlockNumber(blockNumber);
   if (!block) throw new Error('A positive block number is required to execute on the fork.');
-  if (!source || !hubAddress || !calldata) throw new Error('Missing source, hub address, or calldata.');
+  if (!pathData || !source || !receiver || !hubAddress) {
+    throw new Error('Missing path, source, receiver, or hub address.');
+  }
 
   const session = await getTestEnvSession(block);
-  const tx = { from: source, to: hubAddress, data: calldata };
+
+  // Resolve a Safe owner to sign the execTransaction simulation. Circles avatars are Safes.
+  let signer;
+  try {
+    const owners = await readSafeOwnersOnFork(session.anvilUrl, source);
+    if (!owners || owners.length === 0) throw new Error('no owners');
+    signer = owners[0];
+  } catch (err) {
+    if (err?.kind === 'infra') throw err; // network/HTTP — surface as "couldn't run"
+    throw new Error(`Could not read Safe owners for ${source} — execute-on-fork requires a Gnosis Safe avatar.`);
+  }
+
+  // Build the full unwrap → operateFlowMatrix → re-wrap bundle (identical to the Simulate
+  // button), resolving wrapper balances/types against the block-pinned session RPC.
+  const simTx = await buildSafeFlowMatrixSimulationTx({
+    pathData,
+    sender: source,
+    receiver,
+    signer,
+    hubAddress,
+    rpcUrl: session.rpcUrl,
+  });
+
+  const tx = { from: simTx.gasFrom, to: simTx.safeAddress, data: simTx.safeCalldata };
 
   try {
     await anvilRpc(session.anvilUrl, 'eth_call', [tx, 'latest']);
   } catch (err) {
     // Only a genuine contract revert is a "would-fail-on-chain" signal. Infra failures
-    // (network, HTTP, timeout, expired session) are rethrown so the UI shows "couldn't
-    // run" rather than a misleading revert that looks like a pathfinder bug.
+    // (network, HTTP, timeout, expired session) are rethrown so the UI shows "couldn't run".
     if (err?.kind === 'revert') {
       return { success: false, revertReason: decodeRevert(err) };
     }
@@ -242,7 +284,7 @@ export const executeFlowMatrixOnFork = async ({ blockNumber, source, hubAddress,
   } catch {
     // gas is informational only
   }
-  return { success: true, gasUsed };
+  return { success: true, gasUsed, unwrapCalls: simTx.summary?.unwrapCalls ?? 0 };
 };
 
 export const processPath = async (rawPath, sourceAddress) => {

--- a/src/services/testEnv.js
+++ b/src/services/testEnv.js
@@ -1,3 +1,5 @@
+import { decodeAbiParameters } from 'viem';
+
 // Thin client for the Circles test environment session API.
 //
 // A session pins a block: the test-env proxies inject `X-Max-Block-Number` server-side,
@@ -156,6 +158,15 @@ export const decodeRevert = (err) => {
     const selector = raw.slice(0, 10).toLowerCase();
     if (KNOWN_ERROR_SELECTORS[selector]) {
       return `${KNOWN_ERROR_SELECTORS[selector]} (${selector})`;
+    }
+    // Standard Error(string) — decode the human-readable reason (e.g. a Safe "GS0xx" code).
+    if (selector === '0x08c379a0') {
+      try {
+        const [message] = decodeAbiParameters([{ type: 'string' }], `0x${raw.slice(10)}`);
+        if (message) return `"${message}"`;
+      } catch {
+        // fall through to the raw selector
+      }
     }
     return `reverted (${selector})`;
   }


### PR DESCRIPTION
## Problem
Execute-on-fork sent only the bare `operateFlowMatrix`. Paths that use **wrapped (ERC-20) balances** (the `WithWrap` default) reverted with `ERC1155InsufficientBalance` — the ERC-1155 was still locked in the wrapper, because the required `wrapper.unwrap()` step was never sent.

## Fix
Build the **same Safe execTransaction bundle the "Simulate" button already uses** (`buildSafeFlowMatrixSimulationTx`: self-approval → `wrapper.unwrap()` → `operateFlowMatrix` → re-wrap), resolving a Safe owner + wrapper data from the fork / block-pinned session RPC, and `eth_call` that on the fork. Also decode `Error(string)` reverts (e.g. Safe `GS0xx` codes) for readable messages, and drop the now-obsolete "wrapped paths revert" gate + note.

## Verified in-UI (agent-browser, staging test-env)
- Non-wrapped path → ✔ succeeds (est. gas ~433k)
- **Wrapped default path at a recent block → ✔ succeeds** (est. gas ~298k) — previously `ERC1155InsufficientBalance`
- A specific old bug-repro wrapped path reverts with a decoded `GS013` (a real property of that path — the tool correctly surfaces it)

## Test plan
- [x] `vite build` clean
- [x] wrapped + non-wrapped paths execute on the fork with correct ✔/✖ + decoded reasons