### PR TITLE
feat(time-travel): gate behind a Test environment toggle

### DIFF
--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -51,6 +51,7 @@ const FlowVisualization = () => {
     handleTokensChange, 
     handleWithWrapToggle,
     handleStagingToggle,
+    handleTestEnvModeToggle,
     handleQuantizedModeToggle,
     handleDebugIntermediateToggle,
     handleFromTokensExclusionToggle,
@@ -836,6 +837,7 @@ const FlowVisualization = () => {
             handleTokensChange={handleTokensChange}
             handleWithWrapToggle={handleWithWrapToggle}
             handleStagingToggle={handleStagingToggle}
+            handleTestEnvModeToggle={handleTestEnvModeToggle}
             handleQuantizedModeToggle={handleQuantizedModeToggle}
             handleDebugIntermediateToggle={handleDebugIntermediateToggle}
             handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -59,6 +59,7 @@ const PathFinderForm = ({
   handleTokensChange,
   handleWithWrapToggle,
   handleStagingToggle,
+  handleTestEnvModeToggle,
   handleQuantizedModeToggle,
   handleDebugIntermediateToggle,
   handleFromTokensExclusionToggle,
@@ -375,6 +376,16 @@ const PathFinderForm = ({
           />
           <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: rpc.staging.aboutcircles.com\n\nCurrently using: ${formData.UseStaging ? 'rpc.staging.aboutcircles.com' : 'rpc.aboutcircles.com'}`} />
         </div>
+        {isTestEnvConfigured() && (
+          <div className="flex items-center">
+            <ToggleSwitch
+              isEnabled={formData.TestEnvMode}
+              onToggle={handleTestEnvModeToggle}
+              label="Test environment (time-travel)"
+            />
+            <InfoTip text="Route pathfinding and fork execution through the Circles test environment: pin to a past block and run the resulting transfer on an Anvil fork. Reveals the Block Number field and the Execute-on-fork button." />
+          </div>
+        )}
         <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
           <ToggleSwitch
             isEnabled={formData.QuantizedMode}
@@ -401,7 +412,7 @@ const PathFinderForm = ({
             type="number"
           />
         </div>
-        {isTestEnvConfigured() && (
+        {isTestEnvConfigured() && formData.TestEnvMode && (
           <div>
             <label className="block text-sm font-medium mb-1">
               Block Number (time-travel)
@@ -649,6 +660,7 @@ PathFinderForm.propTypes = {
     UseStaging: PropTypes.bool.isRequired,
     MaxTransfers: PropTypes.string,
     BlockNumber: PropTypes.string,
+    TestEnvMode: PropTypes.bool,
     IsFromTokensExcluded: PropTypes.bool.isRequired,
     IsToTokensExcluded: PropTypes.bool.isRequired,
     QuantizedMode: PropTypes.bool.isRequired,
@@ -663,6 +675,7 @@ PathFinderForm.propTypes = {
   handleTokensChange: PropTypes.func.isRequired,
   handleWithWrapToggle: PropTypes.func.isRequired,
   handleStagingToggle: PropTypes.func.isRequired,
+  handleTestEnvModeToggle: PropTypes.func,
   handleQuantizedModeToggle: PropTypes.func.isRequired,
   handleDebugIntermediateToggle: PropTypes.func.isRequired,
   handleFromTokensExclusionToggle: PropTypes.func.isRequired,

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -42,6 +42,7 @@ const DEFAULTS = {
   SimulatedBalances: '[]',
   SimulatedTrusts: '[]',
   SimulatedConsentedAvatars: '',
+  TestEnvMode: false,
   BlockNumber: '',
 };
 
@@ -208,6 +209,15 @@ export const useFormData = () => {
     }));
   };
 
+  const handleTestEnvModeToggle = () => {
+    setFormData(prev => ({
+      ...prev,
+      TestEnvMode: !prev.TestEnvMode,
+      // Leaving test-env mode returns pathfinding to head — clear the pinned block.
+      BlockNumber: prev.TestEnvMode ? '' : prev.BlockNumber,
+    }));
+  };
+
   const handleQuantizedModeToggle = () => {
     setFormData(prev => ({
       ...prev,
@@ -367,6 +377,7 @@ export const useFormData = () => {
     handleTokensChange,
     handleWithWrapToggle,
     handleStagingToggle,
+    handleTestEnvModeToggle,
     handleQuantizedModeToggle,
     handleDebugIntermediateToggle,
     handleFromTokensExclusionToggle,


### PR DESCRIPTION
Adds a **'Test environment (time-travel)'** switch that reveals the Block Number field + Execute-on-fork controls only when flipped, instead of showing them whenever the app is built with a test-env URL. The toggle itself only renders on builds where the test env is configured (i.e. the staging-pointed deploy), so the default/prod UI is unchanged. Turning it off clears the pinned block so pathfinding returns to head.