### PR TITLE
fix(time-travel): thread test-env toggle handler through the panel

### DIFF
--- a/src/components/CollapsibleLeftPanel.jsx
+++ b/src/components/CollapsibleLeftPanel.jsx
@@ -16,6 +16,7 @@ const CollapsibleLeftPanel = ({
   handleTokensChange,
   handleWithWrapToggle,
   handleStagingToggle,
+  handleTestEnvModeToggle,
   handleQuantizedModeToggle,
   handleDebugIntermediateToggle,
   handleFromTokensExclusionToggle,
@@ -96,6 +97,7 @@ const CollapsibleLeftPanel = ({
                 handleTokensChange={handleTokensChange}
                 handleWithWrapToggle={handleWithWrapToggle}
                 handleStagingToggle={handleStagingToggle}
+                handleTestEnvModeToggle={handleTestEnvModeToggle}
                 handleQuantizedModeToggle={handleQuantizedModeToggle}
                 handleDebugIntermediateToggle={handleDebugIntermediateToggle}
                 handleFromTokensExclusionToggle={handleFromTokensExclusionToggle}


### PR DESCRIPTION
## Problem
The **Test environment (time-travel)** toggle rendered (full opacity, meant to be clickable) but **clicking it did nothing** — it could not be enabled.

## Root cause
`FlowVisualization` mounts `CollapsibleLeftPanel` and passes `handleTestEnvModeToggle`, but `CollapsibleLeftPanel` **neither destructured nor forwarded** it to `PathFinderForm`. Inside the form, `onToggle` was therefore `undefined`, making the click a silent no-op. (`CollapsibleSidebar` has the same omission but is dead code — imported nowhere, already stale on other props — so left untouched.)

## Fix
Thread `handleTestEnvModeToggle` through `CollapsibleLeftPanel` (destructure + forward). Two-line change.

## Verification (agent-browser, dev with VITE_TEST_ENV_URL set)
- [x] `npm run build` clean
- [x] Toggle flips `checked=false → true` on click (previously stuck at false)
- [x] Enabling it reveals the **Block Number (time-travel)** field, as designed
- [x] Screenshot confirms toggle ON (blue) + Block Number field visible