### PR TITLE
fix(time-travel): couple the staging endpoint to time-travel mode

### DIFF
--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -372,13 +372,18 @@ const PathFinderForm = ({
           />
           <InfoTip text="Allow the pathfinder to use ERC20-wrapped Circles tokens. Wrapped tokens have broader trust acceptance but require unwrap/wrap operations before the on-chain transfer." />
         </div>
-        <div className="flex items-center">
+        <div
+          className={`flex items-center${formData.TestEnvMode ? ' opacity-60 pointer-events-none' : ''}`}
+          title={formData.TestEnvMode ? 'Locked on: time-travel runs on the staging test-env' : undefined}
+        >
           <ToggleSwitch
             isEnabled={formData.UseStaging}
             onToggle={handleStagingToggle}
             label="Use Staging Endpoint"
           />
-          <InfoTip text={`Prod: rpc.aboutcircles.com\nStaging: rpc.staging.aboutcircles.com\n\nCurrently using: ${formData.UseStaging ? 'rpc.staging.aboutcircles.com' : 'rpc.aboutcircles.com'}`} />
+          <InfoTip text={formData.TestEnvMode
+            ? 'Locked on while Test environment (time-travel) is active — time-travel routes through the staging test-env, so prod cannot be used.'
+            : `Prod: rpc.aboutcircles.com\nStaging: rpc.staging.aboutcircles.com\n\nCurrently using: ${formData.UseStaging ? 'rpc.staging.aboutcircles.com' : 'rpc.aboutcircles.com'}`} />
         </div>
         {isTestEnvConfigured() && (
           <div className="flex items-center">

--- a/src/hooks/useFormData.js
+++ b/src/hooks/useFormData.js
@@ -210,12 +210,19 @@ export const useFormData = () => {
   };
 
   const handleTestEnvModeToggle = () => {
-    setFormData(prev => ({
-      ...prev,
-      TestEnvMode: !prev.TestEnvMode,
-      // Leaving test-env mode returns pathfinding to head — clear the pinned block.
-      BlockNumber: prev.TestEnvMode ? '' : prev.BlockNumber,
-    }));
+    setFormData(prev => {
+      const enabling = !prev.TestEnvMode;
+      return {
+        ...prev,
+        TestEnvMode: enabling,
+        // Time-travel can ONLY run on the staging test-env (there is no prod test-env),
+        // so enabling it forces the staging endpoint on; disabling returns to prod.
+        // The staging toggle is locked while time-travel is active (see PathFinderForm).
+        UseStaging: enabling ? true : false,
+        // Leaving test-env mode returns pathfinding to head — clear the pinned block.
+        BlockNumber: enabling ? prev.BlockNumber : '',
+      };
+    });
   };
 
   const handleQuantizedModeToggle = () => {


### PR DESCRIPTION
## Problem
The UI allowed a contradictory state: **"Use Staging Endpoint" OFF while "Test environment (time-travel)" ON**. Time-travel can only run on the staging test-env (there is no prod test-env), so this was misleading.

## Fix
- Enabling time-travel **forces `UseStaging` ON** and **locks** the staging toggle (`pointer-events-none` + tooltip explaining why).
- Disabling time-travel returns to prod (`UseStaging` OFF) and clears the pinned block.
- Staging can no longer be flipped off while time-travel is active.

## Verification (agent-browser, dev with VITE_TEST_ENV_URL set — real clicks)
- [x] `npm run build` clean
- [x] Initial: staging OFF, time-travel OFF (no contradiction)
- [x] Click time-travel ON → staging auto-flips ON + Block Number field appears
- [x] Clicking the locked staging toggle leaves it ON (lock holds)
- [x] Click time-travel OFF → staging auto-flips OFF + Block field disappears
- [x] Screenshot confirms staging renders locked-on (dimmed blue)