### PR TITLE
feat(pathfinder): enable Quantized Mode + Debug Intermediate Steps (raw-RPC workaround)

### DIFF
--- a/src/components/DebugStagesView.jsx
+++ b/src/components/DebugStagesView.jsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+// Renders the pathfinder's `debug` pipeline stages (returned when
+// debugShowIntermediateSteps=true). Each stage is a list of transfer steps
+// { from, to, tokenOwner, value } at a point in the transformation pipeline:
+//   rawPaths       — solver output with token-pool nodes (tpool-0x…)
+//   collapsed      — pools removed, avatar → avatar flows aggregated
+//   routerInserted — group mints routed (avatar → router → group)
+//   sorted         — final on-chain execution order (collateral before mints)
+const STAGES = [
+  { key: 'rawPaths', label: '1 · Raw paths', hint: 'Solver output with token-pool nodes' },
+  { key: 'collapsed', label: '2 · Collapsed', hint: 'Pools removed, flows aggregated' },
+  { key: 'routerInserted', label: '3 · Router inserted', hint: 'Group mints routed via router' },
+  { key: 'sorted', label: '4 · Sorted', hint: 'Final on-chain execution order' },
+];
+
+const short = (address) => {
+  if (typeof address !== 'string' || address.length < 12) return address ?? '';
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+};
+
+const toCrc = (weiString) => {
+  try {
+    const wei = BigInt(weiString);
+    // Whole-CRC with 3 decimals, without floating-point error on large uint256 values.
+    const whole = wei / 10n ** 18n;
+    const frac = (wei % 10n ** 18n) / 10n ** 15n; // 3 decimal places
+    return `${whole}.${frac.toString().padStart(3, '0')}`;
+  } catch {
+    return String(weiString ?? '');
+  }
+};
+
+const StageSection = ({ stage, steps }) => {
+  const [open, setOpen] = useState(false);
+  const count = steps.length;
+
+  return (
+    <div className="rounded-md border border-input">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between px-3 py-2 text-sm font-medium"
+      >
+        <span className="flex items-center gap-2">
+          {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          {stage.label}
+          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-normal text-gray-600">
+            {count} step{count === 1 ? '' : 's'}
+          </span>
+        </span>
+        <span className="text-[11px] font-normal text-gray-400">{stage.hint}</span>
+      </button>
+      {open && count > 0 && (
+        <div className="overflow-x-auto border-t">
+          <table className="w-full text-left text-xs font-mono">
+            <thead className="bg-gray-50 text-[11px] uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-3 py-1.5 font-semibold">from</th>
+                <th className="px-3 py-1.5 font-semibold">to</th>
+                <th className="px-3 py-1.5 font-semibold">token</th>
+                <th className="px-3 py-1.5 text-right font-semibold">CRC</th>
+              </tr>
+            </thead>
+            <tbody>
+              {steps.map((step, index) => (
+                <tr key={`${stage.key}-${index}`} className="border-t border-gray-100">
+                  <td className="px-3 py-1" title={step.from}>{short(step.from)}</td>
+                  <td className="px-3 py-1" title={step.to}>{short(step.to)}</td>
+                  <td className="px-3 py-1" title={step.tokenOwner}>{short(step.tokenOwner)}</td>
+                  <td className="px-3 py-1 text-right">{toCrc(step.value)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {open && count === 0 && (
+        <p className="border-t px-3 py-2 text-xs text-gray-400">No steps at this stage.</p>
+      )}
+    </div>
+  );
+};
+
+StageSection.propTypes = {
+  stage: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    hint: PropTypes.string.isRequired,
+  }).isRequired,
+  steps: PropTypes.array.isRequired,
+};
+
+const DebugStagesView = ({ debug }) => {
+  if (!debug) {
+    return (
+      <p className="text-sm text-gray-500">
+        No debug stages. Enable “Debug Intermediate Steps” in the form and run Find Path.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-500">
+        Pathfinder transformation pipeline (from “Debug Intermediate Steps”). Each stage shows the
+        transfer steps as they are collapsed, routed, and sorted for on-chain execution.
+      </p>
+      {STAGES.map((stage) => (
+        <StageSection key={stage.key} stage={stage} steps={Array.isArray(debug[stage.key]) ? debug[stage.key] : []} />
+      ))}
+    </div>
+  );
+};
+
+DebugStagesView.propTypes = {
+  debug: PropTypes.shape({
+    rawPaths: PropTypes.array,
+    collapsed: PropTypes.array,
+    routerInserted: PropTypes.array,
+    sorted: PropTypes.array,
+  }),
+};
+
+export default DebugStagesView;

--- a/src/components/FlowVisualization.jsx
+++ b/src/components/FlowVisualization.jsx
@@ -20,6 +20,7 @@ import { checksumAddr } from '@/lib/utils';
 import CopyableAddress from '@/components/ui/copyable-address';
 import InfoTip from '@/components/ui/info-tip';
 import PathStats from '@/components/PathStats';
+import DebugStagesView from '@/components/DebugStagesView';
 
 const FlowVisualization = () => {
   const [isCollapsed, setIsCollapsed] = usePersistedState('panel-collapsed', false);
@@ -1043,6 +1044,14 @@ const FlowVisualization = () => {
                       >
                         Path Stats
                       </TabsTrigger>
+                      {pathData?.debug && (
+                        <TabsTrigger
+                          isActive={activeTab === 'debug'}
+                          onClick={() => setActiveTab('debug')}
+                        >
+                          Pipeline
+                        </TabsTrigger>
+                      )}
                     </TabsList>
                     <div className="flex rounded-md shadow-sm text-xs">
                       <button
@@ -1304,6 +1313,11 @@ const FlowVisualization = () => {
                         showNames={showNames}
                       />
                     </TabsContent>
+                    {pathData?.debug && (
+                      <TabsContent isActive={activeTab === 'debug'} className="h-full overflow-auto">
+                        <DebugStagesView debug={pathData.debug} />
+                      </TabsContent>
+                    )}
                   </div>
                 </Tabs>
               </div>

--- a/src/components/PathFinderForm.jsx
+++ b/src/components/PathFinderForm.jsx
@@ -395,21 +395,21 @@ const PathFinderForm = ({
             <InfoTip text="Route pathfinding and fork execution through the Circles test environment: pin to a past block and run the resulting transfer on an Anvil fork. Reveals the Block Number field and the Execute-on-fork button." />
           </div>
         )}
-        <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
+        <div className="flex items-center">
           <ToggleSwitch
             isEnabled={formData.QuantizedMode}
             onToggle={handleQuantizedModeToggle}
             label="Quantized Mode"
           />
-          <InfoTip text="Not yet supported — awaiting SDK update. Will enable 96 CRC quantization semantics." />
+          <InfoTip text="Invitation module: forces every sink-bound transfer to be exactly N × 96 CRC. The number of invites is derived from the value (invites = value / 96 CRC). Use a very large value to discover all possible invites. Leave off for ordinary transfers." />
         </div>
-        <div className="flex items-center opacity-40 pointer-events-none" title="Not yet supported by SDK">
+        <div className="flex items-center">
           <ToggleSwitch
             isEnabled={formData.DebugShowIntermediateSteps}
             onToggle={handleDebugIntermediateToggle}
             label="Debug Intermediate Steps"
           />
-          <InfoTip text="Not yet supported — awaiting SDK update. Will request intermediate debug details from pathfinder." />
+          <InfoTip text="Returns the pathfinder's transformation stages (raw paths → collapsed → router-inserted → sorted). When on and a path is found, a 'Pipeline' tab appears in the results with each stage." />
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Max Transfers</label>

--- a/src/services/circlesApi.js
+++ b/src/services/circlesApi.js
@@ -117,6 +117,51 @@ export const ethToWei = (crcAmount) => {
   }
 };
 
+// SDK WORKAROUND (remove once @aboutcircles/sdk-rpc supports these fields):
+// Mirrors the SDK's normalizeFindPathParams (PascalCase RPC shape) and adds the three
+// fields the SDK whitelist drops but the backend FlowRequest DTO supports: quantizedMode,
+// debugShowIntermediateSteps, simulatedConsentedAvatars. The RPC binds FlowRequest
+// case-insensitively (the SDK itself sends PascalCase against camelCase JsonPropertyNames),
+// so PascalCase keys resolve. Keep this in lockstep with normalizeFindPathParams until the
+// SDK exposes the missing fields, at which point this helper and its caller are deleted.
+const buildFindPathRpcRequest = (params) => {
+  const request = {
+    Source: params.from,
+    Sink: params.to,
+    TargetFlow: params.targetFlow.toString(),
+    WithWrap: params.useWrappedBalances,
+    // Fields the SDK whitelist drops:
+    QuantizedMode: params.quantizedMode === true,
+    DebugShowIntermediateSteps: params.debugShowIntermediateSteps === true,
+  };
+
+  if (params.fromTokens) request.FromTokens = params.fromTokens;
+  if (params.toTokens) request.ToTokens = params.toTokens;
+  if (params.excludeFromTokens) request.ExcludedFromTokens = params.excludeFromTokens;
+  if (params.excludeToTokens) request.ExcludedToTokens = params.excludeToTokens;
+  if (params.maxTransfers !== undefined) request.MaxTransfers = params.maxTransfers;
+
+  if (params.simulatedBalances) {
+    request.SimulatedBalances = params.simulatedBalances.map((balance) => ({
+      Holder: balance.holder,
+      Token: balance.token,
+      Amount: balance.amount.toString(),
+      IsWrapped: balance.isWrapped,
+      IsStatic: balance.isStatic,
+    }));
+  }
+  if (params.simulatedTrusts) {
+    request.SimulatedTrusts = params.simulatedTrusts.map((trust) => ({
+      Truster: trust.truster,
+      Trustee: trust.trustee,
+    }));
+  }
+  // Also SDK-dropped, but backend-supported (FlowRequest.SimulatedConsentedAvatars):
+  if (params.simulatedConsentedAvatars) request.SimulatedConsentedAvatars = params.simulatedConsentedAvatars;
+
+  return request;
+};
+
 export const findPath = async (formData, sdkRpc) => {
   // Endpoint precedence: block-pinned test-env session > staging toggle > default (head).
   // A pinned session routes RPC (and thus circlesV2_findPath → pathfinder) through the
@@ -196,10 +241,19 @@ export const findPath = async (formData, sdkRpc) => {
 
     console.log('SDK findPath params:', params);
 
-    const result = await rpc.pathfinder.findPath(params);
+    // SDK WORKAROUND (remove once @aboutcircles/sdk-rpc supports these fields):
+    // rpc.pathfinder.findPath() runs params through normalizeFindPathParams, which
+    // WHITELISTS fields and silently drops quantizedMode, debugShowIntermediateSteps and
+    // simulatedConsentedAvatars — even though the backend (circlesV2_findPath → FlowRequest)
+    // supports all three. We issue the call through the SDK's own low-level client with a
+    // request that mirrors normalizeFindPathParams PLUS the dropped fields, so the transport
+    // (URL, JSON-RPC framing, param-array shape) stays identical to the SDK's.
+    //   To switch back when the SDK adds them: delete buildFindPathRpcRequest and restore
+    //   `const result = await rpc.pathfinder.findPath(params);`.
+    const result = await rpc.client.call('circlesV2_findPath', [buildFindPathRpcRequest(params)]);
 
-    // SDK returns bigints — convert to strings for backward compatibility,
-    // including optional debug/simulation payloads.
+    // The raw response already carries string-encoded numbers; stringifyBigInts is a no-op on
+    // strings and recurses the optional `debug` (pipeline stages) / simulation payloads.
     return stringifyBigInts(result);
   } catch (err) {
     console.error('SDK findPath error:', err);
@@ -313,6 +367,9 @@ export const processPath = async (rawPath, sourceAddress) => {
       ...t,
       value: t.value.toString(),
     })),
+    // Pass through the raw pipeline stages untouched (debugShowIntermediateSteps). Wrapper
+    // resolution deliberately does NOT rewrite them — the Pipeline tab shows the raw stages.
+    debug: rawPath.debug,
     _meta: {
       hasWrappedTokens,
       wrappedTokenCount: Object.keys(wrappedTokensInPath).length,


### PR DESCRIPTION
## Why
The SDK's `normalizeFindPathParams` whitelists request fields and **silently drops** `quantizedMode`, `debugShowIntermediateSteps` and `simulatedConsentedAvatars` — even though the backend (`circlesV2_findPath` → `FlowRequest`) supports all three. That's why the two toggles were greyed as *not supported by SDK*. There are **no SDK PRs** for these; they were never in the SDK.

## What
Bypass the whitelist by issuing findPath through the SDK's own low-level client (`rpc.client.call`) with a request that mirrors `normalizeFindPathParams` + the dropped fields. Transport (URL, JSON-RPC framing, param array) is unchanged.

- Un-grey **Quantized Mode** (invitation N×96 CRC) and **Debug Intermediate Steps**.
- New **Pipeline tab** renders the debug stages (raw → collapsed → router-inserted → sorted); `processPath` now passes `debug` through.
- **Switch-back is a one-line revert** once the SDK adds the fields (documented in `circlesApi.js`). Follow-up: SDK PR to add them to `FindPathParams` + `normalizeFindPathParams`.

## Soundness proof (differential test vs production RPC)
- [x] raw-RPC output **byte-identical** to `rpc.pathfinder.findPath` — same `maxFlow` (1000 CRC) + same transfers → the workaround does not change results
- [x] `debug.sorted === transfers` (the sorted stage IS the final on-chain order); stage counts 4/2/2/2
- [x] quantized `maxFlow` = **99264 CRC = 1034 × 96 CRC** (exact 96-CRC multiple → quantization invariant holds)
- [x] agent-browser: toggles un-grey + flip; Find Path returns Routes(1); Pipeline tab renders the stage tables
- [x] `npm run build` clean